### PR TITLE
pfmps: improve the DSFR form builder and use it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,3 +23,6 @@ Style/NegatedIf:
 
 RSpec/NestedGroups:
   Max: 5
+
+Style/HashSyntax:
+  EnforcedShorthandSyntax: either

--- a/app/controllers/pfmps_controller.rb
+++ b/app/controllers/pfmps_controller.rb
@@ -33,11 +33,12 @@ class PfmpsController < StudentsController
   def create
     @pfmp = Pfmp.new(pfmp_params.merge(student: @student))
 
-    if @pfmp.save
-      redirect_to class_student_path(@classe, @student), notice: t("pfmps.new.success")
-    else
-      respond_to do |format|
-        format.html { render :new }
+    respond_to do |format|
+      if @pfmp.save
+        format.html { redirect_to class_student_path(@classe, @student), notice: t("pfmps.new.success") }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @pfmp.errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module TranslationHelper
+  def hint_for(klass, attribute)
+    I18n.t("activerecord.hints.#{klass.model_name.element}.#{attribute}", default: nil)
+  end
+
+  def save_label(klass)
+    cod = save_label_cod(klass)
+
+    I18n.t("activerecord.save_label", cod: cod)
+  end
+
+  def save_label_cod(klass)
+    I18n.t("activerecord.save_labels.#{klass.model_name.element}", default: "de la ressource")
+  end
+end

--- a/app/models/pfmp.rb
+++ b/app/models/pfmp.rb
@@ -6,6 +6,8 @@ class Pfmp < ApplicationRecord
   has_many :transitions, class_name: "PfmpTransition", autosave: false, dependent: :destroy
   has_many :payments, -> { order(updated_at: :asc) }, dependent: :destroy, inverse_of: :pfmp
 
+  validates :start_date, :end_date, presence: true
+
   # FIXME: this is bound to disappear ; a PFMP doesn't really
   # transition into any states, but it might trigger one or more
   # payments and *they* will go through different states. Keeping the

--- a/app/views/pfmps/new.html.haml
+++ b/app/views/pfmps/new.html.haml
@@ -1,17 +1,9 @@
 %h1 Ajouter une PFMP pour #{@student}
 
-= form_with model: @pfmp, url: class_student_pfmps_path(@classe.id, @student.ine), method: "post" do |form|
-  .fr-input-group.fr-col-md-3
-    = form.label :start_date, "Date de début", class: 'fr-label'
-    = form.date_field :start_date, class: 'fr-input'
+= form_with model: @pfmp, url: class_student_pfmps_path(@classe.id, @student.ine), method: "post", builder: DsfrFormBuilder do |form|
+  = form.dsfr_error_summary
 
-  .fr-input-group.fr-col-md-3
-    = form.label :end_date, "Date de fin", class: 'fr-label'
-    = form.date_field :end_date, class: 'fr-input'
+  = form.dsfr_date_field(:start_date, width: 'xs')
+  = form.dsfr_date_field(:end_date, width: 'xs')
 
-  .fr-input-group.fr-col-md-7
-    = form.label :comment, "Commentaire (optionnel)", class: 'fr-label'
-    = form.text_area :comment, class: 'fr-input'
-
-  .fr-input-group
-    = form.submit "Enregistrer", class: 'fr-btn'
+  = form.dsfr_submit "Enregistrer"

--- a/app/views/ribs/new.html.haml
+++ b/app/views/ribs/new.html.haml
@@ -1,15 +1,9 @@
 %h1 Ajout de coordonnés bancaires pour #{@student}
 
 = form_with model: @rib, url: class_student_ribs_path(@classe.id, @student.ine), method: "post", builder: DsfrFormBuilder do |form|
-  - if @rib.errors.any?
-    #error_explanation
-      %h2 L'enregistrement du RIB a échoué à cause de #{pluralize(@rib.errors.count, "erreur")} :
-      %ul
-        - @rib.errors.full_messages.each do |message|
-          %li= message
+  = form.dsfr_error_summary
 
   = form.dsfr_text_field(:iban, code: true, width: 's')
-
   = form.dsfr_text_field(:bic, code: true, width: 'xs')
 
   = form.dsfr_submit "Enregistrer"

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -6,14 +6,20 @@ fr:
       rib:
         iban: "Un IBAN français contient 27 caractères et commence par FR"
         bic: "Le code BIC est composé de 8 ou de 11 caractères"
-
     attributes:
+      pfmp:
+        start_date: "Date de début"
+        end_date: "Date de fin"
       rib:
         iban: "IBAN"
         bic: "BIC"
       establishment:
         uai: "UAI"
         name: "Nom"
+    save_label: "L'enregistrement %{cod} a échoué car :"
+    save_labels:
+      pfmp: "de la PFMP"
+      rib: "du RIB"
   pages:
     titles:
       classes:

--- a/spec/models/pfmp_spec.rb
+++ b/spec/models/pfmp_spec.rb
@@ -10,6 +10,11 @@ RSpec.describe Pfmp do
     it { is_expected.to have_many(:payments) }
   end
 
+  describe "validations" do
+    it { is_expected.to validate_presence_of(:start_date) }
+    it { is_expected.to validate_presence_of(:end_date) }
+  end
+
   describe "payments" do
     context "when the PFMP is new" do
       it "has no payments" do


### PR DESCRIPTION
It's looking a bit like spaghetti code at the moment but it does some *massive* heavy-lifting for us (see the new version of the PFMP form).

I'll get a better idea of the interface rewrite when it gets unbearably ugly.