### PR TITLE
students: add some indirection to request students

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,10 @@ on: push
 env:
   DATABASE_URL: postgres://postgres:dummy@localhost:5432/test
   APLYPRO_ESTABLISHMENTS_BOOTSTRAP_URL: http://data.source/etabs.csv
-  APLYPRO_SYGNE_API: http://sygne/uai/%s
+  APLYPRO_SYGNE_URL: http://sygne/uai/%s
+  APLYPRO_SYGNE_TOKEN_URL: http://sygne/token
+  APLYPRO_SYGNE_SECRET: CI sygne secret
+  APLYPRO_SYGNE_CLIENT_ID: CI sygne client id
   APLYPRO_MEFSTATS_BOOTSTRAP_URL: http://data.source/mefstats.json
   RAILS_ENV: test
 
@@ -75,7 +78,10 @@ jobs:
             --network="host" \
             -e DATABASE_URL \
             -e APLYPRO_ESTABLISHMENTS_BOOTSTRAP_URL \
-            -e APLYPRO_SYGNE_API \
+            -e APLYPRO_SYGNE_URL \
+            -e APLYPRO_SYGNE_CLIENT_ID \
+            -e APLYPRO_SYGNE_SECRET \
+            -e APLYPRO_SYGNE_TOKEN_URL \
             -e APLYPRO_MEFSTATS_BOOTSTRAP_URL \
             -e RAILS_ENV \
             --rm rails-template bundle exec rspec
@@ -107,7 +113,10 @@ jobs:
             --network="host" \
             -e DATABASE_URL \
             -e APLYPRO_ESTABLISHMENTS_BOOTSTRAP_URL \
-            -e APLYPRO_SYGNE_API \
+            -e APLYPRO_SYGNE_URL \
+            -e APLYPRO_SYGNE_CLIENT_ID \
+            -e APLYPRO_SYGNE_SECRET \
+            -e APLYPRO_SYGNE_TOKEN_URL \
             -e APLYPRO_MEFSTATS_BOOTSTRAP_URL \
             -e RAILS_ENV \
             --rm rails-template bundle exec cucumber

--- a/app/api/student_api.rb
+++ b/app/api/student_api.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module StudentApi
+  class << self
+    def fetch_students!(establishment)
+      api_for(establishment).fetch_and_parse!
+    end
+
+    def api_for(establishment)
+      provider = establishment.principal&.provider
+
+      case provider
+      when "fim"
+        Sygne.new(establishment)
+      else
+        raise "Provider has no matching API"
+      end
+    end
+  end
+end

--- a/app/api/student_api/base.rb
+++ b/app/api/student_api/base.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module StudentApi
+  class Base
+    attr_reader :establishment
+
+    def initialize(establishment)
+      @establishment = establishment
+    end
+
+    def endpoint
+      ENV.fetch("APLYPRO_#{identifier}_URL") % @establishment.uai
+    end
+
+    def identifier
+      raise
+    end
+  end
+end

--- a/app/api/student_api/sygne.rb
+++ b/app/api/student_api/sygne.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module StudentApi
+  class Sygne < Base
+    def fetch_and_parse!
+      data = fetch!
+
+      parse!(data)
+    end
+
+    def fetch!
+      with_token = client.access_token!
+
+      with_token.get(endpoint).body
+    end
+
+    def parse!(data)
+      classes = data.group_by { |s| [s["classe"], s["niveau"]] }
+
+      classes.map do |classe, eleves|
+        label, mefstat = classe
+
+        @establishment
+          .classes
+          .find_or_create_by(
+            label:,
+            mefstat: Mefstat.find_or_create_by(code: mefstat)
+          )
+          .tap do |c|
+          c.students << eleves.map { |e| Student.from_sygne_hash(e) }
+        end
+      end
+    end
+
+    def client
+      Rack::OAuth2::Client.new(
+        identifier: ENV.fetch("APLYPRO_SYGNE_CLIENT_ID"),
+        secret: ENV.fetch("APLYPRO_SYGNE_SECRET"),
+        token_endpoint: ENV.fetch("APLYPRO_SYGNE_TOKEN_URL")
+      )
+    end
+
+    def identifier
+      "SYGNE"
+    end
+  end
+end

--- a/app/jobs/fetch_students_job.rb
+++ b/app/jobs/fetch_students_job.rb
@@ -4,32 +4,6 @@ class FetchStudentsJob < ApplicationJob
   queue_as :default
 
   def perform(etab)
-    raw = HTTParty.get(students_url_for(etab))
-    data = JSON.parse(raw.body)
-
-    classes = extract_classes(data, etab)
-
-    classes.each(&:save!)
-  end
-
-  private
-
-  def extract_classes(data, etab)
-    classes = data.group_by { |s| [s["classe"], s["niveau"]] }
-
-    classes.map do |classe, eleves|
-      label, mefstat = classe
-
-      etab
-        .classes
-        .find_or_create_by(label:, mefstat: Mefstat.find_by(code: mefstat))
-        .tap do |c|
-        c.students << eleves.map { |e| Student.from_sygne_hash(e) }
-      end
-    end
-  end
-
-  def students_url_for(etab)
-    URI.parse(ENV.fetch("APLYPRO_SYGNE_API") % etab.uai)
+    StudentApi.fetch_students!(etab)
   end
 end

--- a/app/models/establishment.rb
+++ b/app/models/establishment.rb
@@ -6,6 +6,7 @@ class Establishment < ApplicationRecord
   validates :name, :uai, presence: true
   validates :uai, uniqueness: true
 
+  has_one :principal, dependent: :nullify
   has_many :classes, class_name: "Classe", dependent: :destroy
 
   BOOTSTRAP_URL = ENV.fetch("APLYPRO_ESTABLISHMENTS_BOOTSTRAP_URL")

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -6,7 +6,7 @@ Before do
   FactoryBot.create(:mefstat, code: "1111")
   FactoryBot.create(:mefstat, code: "4221")
 
-  url = ENV.fetch "APLYPRO_SYGNE_API"
+  url = ENV.fetch "APLYPRO_SYGNE_URL"
   fixture = "sygne-students-for-uai.json"
   data = Rails.root.join("mock/data", fixture).read
 

--- a/spec/api/student_api/sygne_spec.rb
+++ b/spec/api/student_api/sygne_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe StudentApi::Sygne do
+  subject(:api) { described_class.new(establishment) }
+
+  let(:establishment) { create(:establishment, :with_fim_principal) }
+  let(:payload) { JSON.generate({ access_token: "foobar", token_type: "Bearer" }) }
+
+  before do
+    fixture = "sygne-students-for-uai.json"
+    data = Rails.root.join("mock/data", fixture).read
+    url = ENV.fetch("APLYPRO_SYGNE_URL") % establishment.uai
+
+    stub_request(:get, url)
+      .with(
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3"
+        }
+      )
+      .to_return(status: 200, body: data, headers: { "Content-Type" => "application/json" })
+
+    stub_request(:post, ENV.fetch("APLYPRO_SYGNE_TOKEN_URL"))
+      .with(
+        body: { "grant_type" => "client_credentials" },
+        headers: {
+          "Accept" => "*/*",
+          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+          "Content-Type" => "application/x-www-form-urlencoded"
+        }
+      )
+      .to_return(status: 200, body: payload, headers: { "Content-Type" => "application/json" })
+  end
+
+  it "grabs an access token before calling the API" do
+    api.fetch!
+
+    expect(WebMock).to have_requested(:post, ENV.fetch("APLYPRO_SYGNE_TOKEN_URL"))
+  end
+end

--- a/spec/api/student_api_spec.rb
+++ b/spec/api/student_api_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe StudentApi do
+  context "when asked for a FIM establishment" do
+    let(:etab) { create(:establishment, :with_fim_principal) }
+    let(:sygne) { instance_double(StudentApi::Sygne) }
+
+    before do
+      allow(StudentApi::Sygne).to receive(:new).and_return sygne
+
+      allow(sygne).to receive(:fetch_and_parse!)
+    end
+
+    it "uses an instance of the SYGNE API" do
+      described_class.fetch_students!(etab)
+
+      expect(sygne).to have_received(:fetch_and_parse!).with(no_args)
+    end
+  end
+
+  context "when asked for an unknown provider" do
+    let(:etab) { create(:establishment) }
+
+    it "raises an error" do
+      expect { described_class.fetch_students!(etab) }.to raise_error(/no matching API/)
+    end
+  end
+end

--- a/spec/factories/establishments.rb
+++ b/spec/factories/establishments.rb
@@ -8,5 +8,9 @@ FactoryBot.define do
     nature { Faker::Number.between(from: 300, to: 399) }
     postal_code { Faker::Address.postcode }
     city { Faker::Address.city }
+
+    trait :with_fim_principal do
+      association :principal, provider: "fim" # rubocop:disable FactoryBot/AssociationStyle
+    end
   end
 end

--- a/spec/jobs/fetch_students_job_spec.rb
+++ b/spec/jobs/fetch_students_job_spec.rb
@@ -3,34 +3,15 @@
 require "rails_helper"
 
 RSpec.describe FetchStudentsJob do
-  let(:etab) { create(:establishment) }
+  let(:etab) { create(:establishment, :with_fim_principal) }
 
   before do
-    fixture = "sygne-students-for-uai.json"
-    data = Rails.root.join("mock/data", fixture).read
-    url = ENV.fetch("APLYPRO_SYGNE_API") % etab.uai
-
-    stub_request(:get, url)
-      .with(
-        headers: {
-          "Accept" => "*/*",
-          "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "User-Agent" => "Ruby"
-        }
-      )
-      .to_return(status: 200, body: data, headers: {})
-
-    create(:mefstat, code: "1111")
-    create(:mefstat, code: "4221")
+    allow(StudentApi).to receive(:fetch_students!)
   end
 
-  it "fetches the students and classes for the etab" do
+  it "calls the matchingStudentApi proxy" do
     described_class.new.perform(etab)
 
-    expect(etab.classes).not_to be_empty
-  end
-
-  it "creates a bunch of student" do
-    expect { described_class.new.perform(etab) }.to change(Student, :count).by(2)
+    expect(StudentApi).to have_received(:fetch_students!).with(etab)
   end
 end

--- a/spec/models/establishment_spec.rb
+++ b/spec/models/establishment_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "csv"
 
 RSpec.describe Establishment do
-  subject(:etab) { build(:establishment) }
+  subject(:etab) { build(:establishment, :with_fim_principal) }
 
   it { is_expected.to validate_presence_of(:name) }
   it { is_expected.to validate_presence_of(:uai) }
@@ -45,6 +45,12 @@ RSpec.describe Establishment do
       end
 
       it { is_expected.to be_second_degree }
+    end
+  end
+
+  describe "principal connection" do
+    it "knows it's got a principal" do
+      expect(etab.principal).not_to be_nil
     end
   end
 end


### PR DESCRIPTION
The StudentsApi module acts as an API proxy that routes to the correct student-fetching API with dedicated classes to wrap the fetching, parsing, mapping and saving of the resources.