### PR TITLE
pfmp: don't show the formation selector quite yet

### DIFF
--- a/app/views/pfmps/_form.html.haml
+++ b/app/views/pfmps/_form.html.haml
@@ -4,10 +4,6 @@
   - unless disabled
     = form.dsfr_error_summary
 
-  .fr-select-group.fr-col-3
-    = form.label :schooling_id, "Formation", class: 'fr-label'
-    = form.select :schooling_id, @student.classes, {}, { class: 'fr-select', disabled: true }
-
   = form.dsfr_date_field(:start_date, width: 'sm-4 md-3 lg-2', disabled:)
   = form.dsfr_date_field(:end_date, width: 'sm-4 md-3 lg-2', disabled:)
 


### PR DESCRIPTION
This will be useful next year so remove the potential confusion until then.