### PR TITLE
css: override the DSFR's ridiculously small font size

### DIFF
--- a/app/assets/stylesheets/dsfr-overrides.css
+++ b/app/assets/stylesheets/dsfr-overrides.css
@@ -25,3 +25,19 @@
   overflow: clip;
   text-overflow: ellipsis;
 }
+
+.fr-hint-text {
+  font-size: 0.95rem;
+}
+
+.fr-nav__link {
+  font-size: 1rem;
+}
+
+.fr-breadcrumb__link {
+  font-size: 0.9rem;
+}
+
+:root {
+  --text-mention-grey: #585858; /* complies with AAA 7:1 contrast ratio */
+}


### PR DESCRIPTION
A lot of our user-testing interviews included people completely missing the hints (12px!!!!!) and even the top-level menu items. The font is way too small on a lot of components so we're going to defy compliance and make this goddamn website accessible for everybody.