### PR TITLE
auth: better handling of exceptions

### DIFF
--- a/app/models/concerns/identity_mappers/errors.rb
+++ b/app/models/concerns/identity_mappers/errors.rb
@@ -2,7 +2,15 @@
 
 module IdentityMappers
   module Errors
-    class EmptyResponsibilitiesError < StandardError
+    class Error < StandardError; end
+
+    class OmniauthError < Error
+      def initialize(msg = "Omniauth failed without an exception")
+        super(msg)
+      end
+    end
+
+    class EmptyResponsibilitiesError < Error
       attr_reader :attributes
 
       def initialize(msg = "No responsibilites indicated", attributes = {})

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -68,20 +68,21 @@ fr:
     service_name: "Aplypro"
     service_description: "Allocation pour les lycéens professionnels"
   auth:
-    no_responsibilities:
-      title: "Erreur d'authentification"
-      content: |
-        Le guichet d'authentification n'indique aucun établissement sous
-        votre direction. Aplypro n'est ouvert qu'aux personnels de
-        direction pour le moment. Il peut s'agir d'une erreur dans la
-        configuration de votre profil. Nos équipes ont été
-        notifiées.
+    errors:
+      omniauth_error:
+        title: La connexion a échoué
+        content: |
+          Une erreur inconnue a eu lieu pendant la connexion. L'équipe
+          technique a été notifiée du problème.
+      empty_responsibilities_error:
+        title: "Erreur d'authentification"
+        content: |
+          Le guichet d'authentification n'indique aucun établissement sous
+          votre direction. Aplypro n'est ouvert qu'aux personnels de
+          direction pour le moment. Il peut s'agir d'une erreur dans la
+          configuration de votre profil. Nos équipes ont été
+          notifiées.
     success: "Connexion réussie"
-    failure:
-      title: La connexion a échoué
-      content: |
-        Une erreur inconnue a eu lieu pendant la connexion. L'équipe
-        technique a été notifiée du problème.
 
   ribs:
     create:

--- a/features/premiere_connexion.feature
+++ b/features/premiere_connexion.feature
@@ -25,3 +25,4 @@ Fonctionnalité: Le personnel de direction se connecte
     Sachant que je suis un personnel MENJ de l'établissement "123"
     Quand je me connecte en tant que personnel MENJ
     Alors la page contient "aucun établissement sous votre direction"
+    Et il n'y a pas de personnel de direction enregistré dans la base de données

--- a/features/step_definitions/perdir_steps.rb
+++ b/features/step_definitions/perdir_steps.rb
@@ -119,3 +119,7 @@ Quand("je renseigne {int} jours pour la dernière PFMP de {string}") do |days, n
     Et que je clique sur "Modifier la PFMP"
   )
 end
+
+Alors("il n'y a pas de personnel de direction enregistré dans la base de données") do
+  expect(Principal.count).to eq 0
+end


### PR DESCRIPTION
We're piggybacking ActionController's `rescue_from` hook to catch any errors we might potentially throw (safely scoped to our namespace) and redirect with a nicely inferred flash message.

This means a lot of the auth logic can now resort to:

check_something!
check_something_else!

and create+raise any error that comes up without causing a crash on the frontend, and without us losing the error on the backend either.