### PR TITLE
ux: use direct links rather than separate "View the X" actions

### DIFF
--- a/app/models/classe.rb
+++ b/app/models/classe.rb
@@ -15,6 +15,10 @@ class Classe < ApplicationRecord
   end
 
   def to_s
-    label
+    "Classe de #{label}"
+  end
+
+  def to_long_s
+    [label, mef.specialty].join(" - ")
   end
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -27,6 +27,10 @@ class Student < ApplicationRecord
     [first_name, last_name].join(" ")
   end
 
+  def index_name
+    [last_name, first_name].join(" ")
+  end
+
   def used_allowance
     payments.in_state(:success).map(&:amount).sum
   end

--- a/app/views/classes/index.html.haml
+++ b/app/views/classes/index.html.haml
@@ -5,18 +5,15 @@
     %table
       %caption.fr-h1 Liste des classes
       %thead
-        %th{scope: "col"} Label
-        %th{scope: "col"} Formation
+        %th{scope: "col"} Classe
         %th{scope: "col"} Effectif
         %th{scope: "col"} Nombre de PFMPs
         %th{scope: "col"} Coordonnées bancaires
-        %th{scope: "col"} Actions
       %tbody
         - @classes.each do |classe|
           %tr
-            %td= classe.label
-            %td= classe.mef.specialty
+            %td
+              = dsfr_link_to classe.to_long_s, classe, title: t("links.classes.show", label: classe.to_long_s)
             %td= classe.students.size
             %td= classe.students.map(&:pfmps).flatten.size
             %td= avancement_ribs(classe)
-            %td= dsfr_link_to 'Voir les élèves', classe

--- a/app/views/classes/show.html.haml
+++ b/app/views/classes/show.html.haml
@@ -5,26 +5,24 @@
   %table
     %caption Liste des élèves (#{@classe.students.count})
     %thead
-      %th{scope: "col"} Nom
-      %th{scope: "col"} Prénom
+      %th{scope: "col"} Élève
       %th{scope: "col"} PFMPs
       %th{scope: "col"} RIB présent
-      %th{scope: "col"} Actions
 
     %tbody
       - @classe.students.each do |student|
         %tr
-          %td= student.last_name
-          %td= student.first_name
           %td
-            %ul
-            - student.pfmps.each do |pfmp|
-              %li= dsfr_link_to pfmp.listing_to_s, class_student_pfmp_path(@classe, student, pfmp)
+            = dsfr_link_to student.index_name, class_student_path(@classe, student), title: t("links.students.show", name: student)
+          %td
+            - if student.pfmps.none?
+              aucune
+            - else
+              %ul
+                - student.pfmps.each do |pfmp|
+                  %li= dsfr_link_to pfmp.listing_to_s, class_student_pfmp_path(@classe, student, pfmp)
           %td
             - if student.rib.present?
               = dsfr_badge(status: :success) { "Oui"}
             - else
               = dsfr_link_to "Rajouter le RIB", new_class_student_rib_path(@classe, student)
-          %td
-            -# FIXME: we cannot have the INE in the URL
-            = dsfr_link_to "Voir le profil de l'élève", class_student_path(@classe, student)

--- a/app/views/pfmps/_pfmp_student_table.html.haml
+++ b/app/views/pfmps/_pfmp_student_table.html.haml
@@ -1,22 +1,14 @@
-.fr-table.fr-table--layout-fixed
+.fr-table.fr-table--layout-fixed.fr-table--no-caption
   %table
     %caption Liste des PFMPs de l'élève
     %thead
-      %th{scope: "col"} État
-      %th{scope: "col"} Date de début
-      %th{scope: "col"} Date de fin
+      %th{scope: "col"} PFMP
       %th{scope: "col"} Nombre de jours
       %th{scope: "col"} Montant
-      %th{scope: "col"} Actions
     %tbody
       - @student.pfmps.each do |pfmp|
         %tr
-          %td= pfmp.status_badge
-          %td= l pfmp.start_date
-          %td= l pfmp.end_date
+          %td= dsfr_link_to pfmp.listing_to_s, class_student_pfmp_path(@classe, @student, pfmp), title: "Voir la PFMP"
           %td= pfmp.day_count
           %td
             %strong= number_to_currency(pfmp.calculate_amount)
-          %td
-            %ul
-              %li= dsfr_link_to('Voir la PFMP', class_student_pfmp_path(@classe, @student, pfmp))

--- a/app/views/students/show.html.haml
+++ b/app/views/students/show.html.haml
@@ -1,6 +1,6 @@
 - content_for(:page_title) { [@page_title, t("pages.titles.classes.show", name: @classe.label)].join(" - ") }
 
-%section.fr-mb-3w
+%section
   %h2.fr-h4 Coordonnées bancaires
 
   - if @student.rib.nil?
@@ -21,10 +21,12 @@
 
     = link_to "Modifier les coordonnées bancaires", edit_class_student_rib_path(@classe.id, @student.id, @student.rib.id), class: 'fr-btn fr-btn--secondary'
 
-- if @student.pfmps.none?
-  %p Aucune PFMP enregistrée pour le moment.
-- else
-  = render partial: 'pfmps/pfmp_student_table'
+%section.fr-mt-3w
+  %h2.fr-h4 Liste des PFMPs de l'élève
+  - if @student.pfmps.none?
+    %p Aucune PFMP enregistrée pour le moment.
+  - else
+    = render partial: 'pfmps/pfmp_student_table'
 
 .actions.fr-py-3w
   = link_to "Ajouter une PFMP", new_class_student_pfmp_path(@classe, @student), class: 'fr-btn'

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -8,6 +8,11 @@ fr:
         create: Enregistrer la PFMP
         update: Modifier la PFMP
   format: "L'attribut %{attribute} %{message}"
+  links:
+    classes:
+      show: "Voir la classe de %{label}"
+    students:
+      show: "Voir le profil de %{name}"
   errors:
     classes:
       not_found: "La classe que vous avez demandée n'existe pas."

--- a/features/consultation_des_listes.feature
+++ b/features/consultation_des_listes.feature
@@ -8,10 +8,10 @@ Fonctionnalité: Le personnel de direction consulte les listes
     Et que je rafraîchis la page
 
   Scénario: Le personnel de direction consulte le profil d'un élève
-    Quand je clique sur "Voir les élèves" dans la rangée "3EMEB"
-    Et que je clique sur "Voir le profil de l'élève" dans la rangée "Curie Marie"
+    Quand je clique sur "Voir la classe" dans la rangée "3EMEB"
+    Et que je clique sur "Voir le profil" dans la rangée "Curie Marie"
     Alors la page est titrée "Marie Curie"
-    Et le fil d'Ariane affiche "Liste des classes > 3EMEB > Marie Curie"
+    Et le fil d'Ariane affiche "Liste des classes > Classe de 3EMEB > Marie Curie"
 
   Scénario: Le personnel de direction peut voir la complétion des saisies de coordonnées bancaires
     Quand je renseigne les coordonnées bancaires de l'élève "Marie Curie" de la classe "3EMEB"

--- a/features/gestion_de_pfmp.feature
+++ b/features/gestion_de_pfmp.feature
@@ -7,8 +7,8 @@ Fonctionnalité: Le personnel de direction édite les PFMPs
     Et que mon établissement propose une formation "Développement" rémunérée à 15 euros par jour et plafonnée à 200 euros par an
     Et qu'il y a une élève "Marie Curie" au sein de la classe "3EMEB" pour une formation "Développement"
     Quand je rafraîchis la page
-    Et que je clique sur "Voir les élèves" dans la rangée "3EMEB"
-    Et que je clique sur "Voir le profil de l'élève" dans la rangée "Curie Marie"
+    Et que je clique sur "Voir la classe" dans la rangée "3EMEB"
+    Et que je clique sur "Voir le profil" dans la rangée "Curie Marie"
 
   Scénario: Le personnel de direction peut voir le nombre de PFMP réalisée
     Quand l'élève n'a réalisé aucune PFMP
@@ -18,8 +18,8 @@ Fonctionnalité: Le personnel de direction édite les PFMPs
     Quand je renseigne une PFMP de 3 jours pour "Marie Curie"
     Alors la page contient "La PFMP a été enregistrée avec succès"
     Et je peux voir dans le tableau "Liste des PFMPs de l'élève"
-      | État      | Date de début | Date de fin | Nombre de jours | Montant | Actions      |
-      | Complétée | 17/03/2023    | 20/03/2023  |               3 | 45,00 € | Voir la PFMP |
+      | État      | Nombre de jours | Montant |
+      | Complétée |               3 | 45,00 € |
 
   Scénario: Le personnel de direction peut rajouter une PFMP pour toute la classe
     Quand je vais voir la classe "3EMEB"
@@ -37,8 +37,8 @@ Fonctionnalité: Le personnel de direction édite les PFMPs
     Et que je clique sur "Modifier la PFMP"
     Alors la page contient "La PFMP a bien été mise à jour"
     Et je peux voir dans le tableau "Liste des PFMPs de l'élève"
-      | État      | Date de début | Date de fin | Nombre de jours | Montant  | Actions      |
-      | Complétée | 17/03/2023    | 20/03/2023  |              10 | 150,00 € | Voir la PFMP |
+      | État      |  Nombre de jours | Montant
+      | Complétée |               10 | 150,00 €
 
   Scénario: Le personnel de direction peut valider une PFMP individuellement
     Quand je renseigne une PFMP de 3 jours pour "Marie Curie"

--- a/features/saisie_de_coordonnees_bancaires.feature
+++ b/features/saisie_de_coordonnees_bancaires.feature
@@ -6,8 +6,8 @@ Fonctionnalité: Le personnel de direction saisit des coordonnées bancaires
     Et que je me connecte en tant que personnel MENJ
     Et qu'il y a une élève "Marie Curie" au sein de la classe "3EMEB" pour une formation "Développement"
     Et que je rafraîchis la page
-    Et que je clique sur "Voir les élèves" dans la rangée "3EMEB"
-    Et que je clique sur "Voir le profil de l'élève" dans la rangée "Curie Marie"
+    Et que je clique sur "Voir la classe" dans la rangée "3EMEB"
+    Et que je clique sur "Voir le profil" dans la rangée "Curie Marie"
 
   Scénario: Le personnel de direction saisit un RIB pour la première fois
     Sachant que la page contient "Aucune coordonnées bancaires enregistrées"


### PR DESCRIPTION
It was noted during user research, having separate "view the class", "view the student", "view the PFMP" actions is confusing and force mouse-travel which no one likes.

Use the `title` attribute to ensure we keep them legible and clear.