### PR TITLE
auth: customise the dev strategy

### DIFF
--- a/app/models/principal.rb
+++ b/app/models/principal.rb
@@ -36,9 +36,10 @@ class Principal < ApplicationRecord
           "credentials" => {
             "token" => "dev token"
           },
+          "uid" => "developer",
           "info" => {
-            "name" => attrs["uid"],
-            "email" => attrs["uid"]
+            "name" => "Aplypo Dev",
+            "email" => "aplypro-dev@beta.gouv.fr"
           }
         }
       )

--- a/app/views/home/login.html.haml
+++ b/app/views/home/login.html.haml
@@ -4,7 +4,8 @@
   %p
     Vous devez vous connecter pour accéder à Aplypro et à la gestion
     des PFMPs.
-- if ENV.fetch("APLYPRO_ENV") == "development"
+- true_production = Rails.env.production? && ENV.fetch("APLYPRO_ENV") == "production"
+- unless true_production
   = button_to "Auth développeur",
     principal_developer_omniauth_authorize_path,
     method: :post,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,9 +272,11 @@ Devise.setup do |config|
   config.sign_out_via = :delete
 
   # ==> OmniAuth
-  unless Rails.env.production?
+  true_production = Rails.env.production? && ENV.fetch("APLYPRO_ENV") == "production"
+
+  unless true_production
     config.omniauth :developer,
-                    fields: %i[email name uai provider]
+                    fields: [:uai, { provider: %i[masa fim] }]
   end
 
   config.omniauth :openid_connect, {

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,3 +1,53 @@
 # frozen_string_literal: true
 
 OmniAuth.config.logger = Rails.logger
+
+# NOTE: this code allows for multiple-choice fields in the Omniauth
+# dev strategy, rendered as <select> elements. It's not the best code
+# but it will allow the team to try logging in as any establishment
+# with the relevant ministry.
+module OmniAuth
+  class Form
+    def select_field(hash)
+      key, values = hash.first
+
+      label_field(key, key.capitalize)
+
+      @html << "\n<select name='#{key}'>\n"
+
+      values.each do |value|
+        @html << "\n<option value='#{value}'>#{value}</option>"
+      end
+
+      @html << "\n</select>"
+    end
+  end
+
+  module Strategies
+    class Developer
+      def request_phase
+        form = OmniAuth::Form.new(title: "User Info", url: callback_path)
+        options.fields.each do |field|
+          if field.is_a? Hash
+            form.select_field(field)
+          else
+            form.text_field field.to_s.capitalize.tr("_", " "), field.to_s
+          end
+        end
+        form.button "Sign In"
+        form.to_response
+      end
+
+      info do
+        options.fields.each_with_object({}) do |field, hash|
+          if field.is_a? Hash
+            key = field.keys.first
+            hash[key] = request.params[key]
+          else
+            hash[field] = request.params[field.to_s]
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've turned on Review Apps on Scalingo which means triggering a new environement to try out the changes in the pull request. It's a great feature, and something that's going to prove very useful in the near future.

Because the review apps are deployed on custom, temporary domains (i.e `aplypro-test-prNUMBER.osc-fr1.scalingo.io`), we cannot use OIDC because the redirect_uris don't match.

Instead, restore the dev strategy and allow <select> to choose the relevant ministry.