### PR TITLE
docker: remove installation of curl and docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:3.2-slim
 
 EXPOSE 3000
 
-RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y curl build-essential docker libpq-dev nodejs npm
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y build-essential libpq-dev nodejs npm
 
 # do the bundle install in another directory with the strict essential
 # (Gemfile and Gemfile.lock) to allow further steps to be cached


### PR DESCRIPTION
Docker is a leftover from the rails template and curl was for the manual node installation.