### PR TITLE
auth: don't skip the authenticity token

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,8 +5,6 @@ module Users
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     include DeveloperOidc
 
-    skip_before_action :verify_authenticity_token
-
     rescue_from IdentityMappers::Errors::Error, ActiveRecord::RecordInvalid, with: :authentication_failure
 
     def developer


### PR DESCRIPTION
NOTE: unsure this works, just need it deployed to some test environment to see whether it's just my local setup or the fake auth strategy that is causing ActionController::InvalidAuthenticityToken in my browser.