### PR TITLE
db: restore regular primary keys

### DIFF
--- a/app/controllers/pfmps_controller.rb
+++ b/app/controllers/pfmps_controller.rb
@@ -112,7 +112,7 @@ class PfmpsController < ApplicationController
   end
 
   def set_student
-    @student = @classe.students.find_by(ine: params[:student_id])
+    @student = @classe.students.find(params[:student_id])
   end
 
   def set_classe

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -13,7 +13,7 @@ class StudentsController < ClassesController
   private
 
   def set_student
-    @student = @classe.students.includes(:rib, :pfmps).find_by(ine: params[:id])
+    @student = @classe.students.includes(:rib, :pfmps).find(params[:id])
   end
 
   def set_classe

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -75,12 +75,16 @@ module Users
 
     def save_roles!
       @mapper.establishments.each do |e|
+        e.save! unless e.persisted?
+
         EstablishmentUserRole
           .where(user: @user, establishment: e, role: :dir)
           .first_or_create
       end
 
       @mapper.authorised_establishments_for(@user.email).each do |e|
+        e.save! unless e.persisted?
+
         EstablishmentUserRole
           .where(user: @user, establishment: e, role: :authorised)
           .first_or_create

--- a/app/models/establishment.rb
+++ b/app/models/establishment.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Establishment < ApplicationRecord
-  self.primary_key = "uai"
-
   validates :uai, presence: true, uniqueness: true
 
   has_many :invitations, dependent: :nullify

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Student < ApplicationRecord
-  self.primary_key = "ine"
-
   validates :ine, :first_name, :last_name, :birthdate, presence: true
 
   has_many :schoolings, dependent: :destroy

--- a/db/migrate/20230512084221_create_establishments.rb
+++ b/db/migrate/20230512084221_create_establishments.rb
@@ -2,15 +2,15 @@
 
 class CreateEstablishments < ActiveRecord::Migration[7.0]
   def change
-    create_table :establishments, id: false do |t|
-      t.string :uai, primary_key: true, null: false
+    create_table :establishments do |t|
+      t.string :uai, null: false
       t.string :name, null: false
       t.string :denomination, null: false
       t.string :nature, null: false
 
       t.timestamps
-    end
 
-    add_index :establishments, :uai, unique: true
+      t.index :uai, unique: true
+    end
   end
 end

--- a/db/migrate/20230516161726_create_classes.rb
+++ b/db/migrate/20230516161726_create_classes.rb
@@ -3,13 +3,11 @@
 class CreateClasses < ActiveRecord::Migration[7.0]
   def change
     create_table :classes do |t|
+      t.references :establishment
       t.references :mefstat, null: false, foreign_key: true
       t.string :label
 
       t.timestamps
     end
-
-    add_column :classes, :establishment_id, :string, null: false
-    add_foreign_key :classes, :establishments, primary_key: "uai"
   end
 end

--- a/db/migrate/20230517062450_add_establishment_id_to_principals.rb
+++ b/db/migrate/20230517062450_add_establishment_id_to_principals.rb
@@ -2,7 +2,8 @@
 
 class AddEstablishmentIdToPrincipals < ActiveRecord::Migration[7.0]
   def change
-    add_column :principals, :establishment_id, :string, null: false
-    add_foreign_key :principals, :establishments, primary_key: "uai"
+    change_table :principals do |t|
+      t.references :establishment, foreign_key: true, null: false
+    end
   end
 end

--- a/db/migrate/20230522131051_create_students.rb
+++ b/db/migrate/20230522131051_create_students.rb
@@ -2,13 +2,14 @@
 
 class CreateStudents < ActiveRecord::Migration[7.0]
   def change
-    create_table :students, id: false do |t|
-      t.references :classe, null: false, foreign_key: true
-      t.string :ine, primary_key: true, null: false
+    create_table :students do |t|
+      t.string :ine, null: false
       t.string :first_name
       t.string :last_name
 
       t.timestamps
+
+      t.index :ine, unique: true
     end
   end
 end

--- a/db/migrate/20230522230816_create_pfmps.rb
+++ b/db/migrate/20230522230816_create_pfmps.rb
@@ -7,8 +7,5 @@ class CreatePfmps < ActiveRecord::Migration[7.0]
       t.date :end_date
       t.timestamps
     end
-
-    add_column :pfmps, :student_id, :string, null: false
-    add_foreign_key :pfmps, :students, primary_key: "ine"
   end
 end

--- a/db/migrate/20230606160103_create_ribs.rb
+++ b/db/migrate/20230606160103_create_ribs.rb
@@ -3,14 +3,12 @@
 class CreateRibs < ActiveRecord::Migration[7.0]
   def change
     create_table :ribs do |t|
+      t.references :student, null: false, foreign_key: true
       t.string :iban
       t.string :bic
       t.timestamp :archived_at
 
       t.timestamps
     end
-
-    add_column :ribs, :student_id, :string, null: false # rubocop:disable Rails/NotNullColumn
-    add_foreign_key :ribs, :students, primary_key: "ine"
   end
 end

--- a/db/migrate/20230826134628_create_schoolings.rb
+++ b/db/migrate/20230826134628_create_schoolings.rb
@@ -3,28 +3,20 @@
 class CreateSchoolings < ActiveRecord::Migration[7.0]
   def change
     create_table(:schoolings) do |t|
+      t.references :student, null: false, foreign_key: true
+      t.references :classe, null: false, foreign_key: true
       t.date :start_date
       t.date :end_date
-      t.references :student, type: :string, null: false
-      t.references :classe, null: false, foreign_key: true
 
       t.timestamps
     end
 
     change_table(:pfmps) do |t|
-      t.remove_references :student, primary_key: "ine"
       t.references :schooling, foreign_key: true, null: false
     end
 
     change_table(:students) do |t|
-      t.remove_references :classe, null: false
-      t.column :current_schooling, :bigint
-
-      t.foreign_key :schoolings, column: :current_schooling
+      t.references :current_schooling, foreign_key: { to_table: :schoolings }
     end
-
-    # we need to do this here as `t.references` doesn't let us specify
-    # the different primary key name (I think).
-    add_foreign_key :schoolings, :students, primary_key: "ine"
   end
 end

--- a/db/migrate/20231011223534_create_invitations.rb
+++ b/db/migrate/20231011223534_create_invitations.rb
@@ -3,15 +3,13 @@
 class CreateInvitations < ActiveRecord::Migration[7.1]
   def change
     create_table :invitations do |t|
+      t.references :establishment, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true
 
       t.string :email, null: false
 
       t.timestamps
     end
-
-    add_column :invitations, :establishment_id, :string, null: false # rubocop:disable Rails:NotNullColumn
-    add_foreign_key :invitations, :establishments, primary_key: "uai"
 
     add_index :invitations, %i[establishment_id email], unique: true
   end

--- a/db/migrate/20231012102522_create_join_table_establishment_users.rb
+++ b/db/migrate/20231012102522_create_join_table_establishment_users.rb
@@ -3,13 +3,11 @@
 class CreateJoinTableEstablishmentUsers < ActiveRecord::Migration[7.1]
   def change
     create_table :establishment_users, id: false do |t|
-      t.references :user, foreign_key: true
+      t.references :establishment, foreign_key: true, null: false
+      t.references :user, foreign_key: true, null: false
       t.references :granted_by, foreign_key: { to_table: :users }
 
       t.integer :role, null: false
     end
-
-    add_column :establishment_users, :establishment_id, :string, null: false # rubocop:disable Rails:NotNullColumn
-    add_foreign_key :establishment_users, :establishments, primary_key: "uai"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,26 +43,29 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_16_101548) do
   end
 
   create_table "classes", force: :cascade do |t|
+    t.bigint "establishment_id"
     t.bigint "mef_id", null: false
     t.string "label"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "establishment_id", null: false
     t.string "start_year", null: false
+    t.index ["establishment_id"], name: "index_classes_on_establishment_id"
     t.index ["mef_id"], name: "index_classes_on_mef_id"
   end
 
   create_table "establishment_user_roles", id: false, force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "establishment_id", null: false
+    t.bigint "user_id", null: false
     t.bigint "granted_by_id"
     t.integer "role", null: false
-    t.string "establishment_id", null: false
     t.index ["establishment_id", "user_id"], name: "index_establishment_user_roles_on_establishment_id_and_user_id", unique: true
+    t.index ["establishment_id"], name: "index_establishment_user_roles_on_establishment_id"
     t.index ["granted_by_id"], name: "index_establishment_user_roles_on_granted_by_id"
     t.index ["user_id"], name: "index_establishment_user_roles_on_user_id"
   end
 
-  create_table "establishments", primary_key: "uai", id: :string, force: :cascade do |t|
+  create_table "establishments", force: :cascade do |t|
+    t.string "uai", null: false
     t.string "name"
     t.string "denomination"
     t.string "nature"
@@ -78,12 +81,13 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_16_101548) do
   end
 
   create_table "invitations", force: :cascade do |t|
+    t.bigint "establishment_id", null: false
     t.bigint "user_id", null: false
     t.string "email", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "establishment_id", null: false
     t.index ["establishment_id", "email"], name: "index_invitations_on_establishment_id_and_email", unique: true
+    t.index ["establishment_id"], name: "index_invitations_on_establishment_id"
     t.index ["user_id"], name: "index_invitations_on_user_id"
   end
 
@@ -142,34 +146,38 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_16_101548) do
   end
 
   create_table "ribs", force: :cascade do |t|
+    t.bigint "student_id", null: false
     t.string "iban"
     t.string "bic"
     t.datetime "archived_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "student_id", null: false
     t.string "name", null: false
     t.boolean "personal", default: false, null: false
+    t.index ["student_id"], name: "index_ribs_on_student_id"
   end
 
   create_table "schoolings", force: :cascade do |t|
+    t.bigint "student_id", null: false
+    t.bigint "classe_id", null: false
     t.date "start_date"
     t.date "end_date"
-    t.string "student_id", null: false
-    t.bigint "classe_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["classe_id"], name: "index_schoolings_on_classe_id"
     t.index ["student_id"], name: "index_schoolings_on_student_id"
   end
 
-  create_table "students", primary_key: "ine", id: :string, force: :cascade do |t|
+  create_table "students", force: :cascade do |t|
+    t.string "ine", null: false
     t.string "first_name"
     t.string "last_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "birthdate", null: false
-    t.bigint "current_schooling"
+    t.bigint "current_schooling_id"
+    t.index ["current_schooling_id"], name: "index_students_on_current_schooling_id"
+    t.index ["ine"], name: "index_students_on_ine", unique: true
   end
 
   create_table "users", force: :cascade do |t|
@@ -187,9 +195,10 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_16_101548) do
     t.datetime "last_sign_in_at"
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
-    t.string "establishment_id"
+    t.bigint "establishment_id"
     t.boolean "welcomed", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["establishment_id"], name: "index_users_on_establishment_id"
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
@@ -203,20 +212,19 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_16_101548) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "classes", "establishments", primary_key: "uai"
   add_foreign_key "classes", "mefs"
-  add_foreign_key "establishment_user_roles", "establishments", primary_key: "uai"
+  add_foreign_key "establishment_user_roles", "establishments"
   add_foreign_key "establishment_user_roles", "users"
   add_foreign_key "establishment_user_roles", "users", column: "granted_by_id"
-  add_foreign_key "invitations", "establishments", primary_key: "uai"
+  add_foreign_key "invitations", "establishments"
   add_foreign_key "invitations", "users"
   add_foreign_key "payment_transitions", "payments"
   add_foreign_key "payments", "pfmps"
   add_foreign_key "pfmp_transitions", "pfmps"
   add_foreign_key "pfmps", "schoolings"
-  add_foreign_key "ribs", "students", primary_key: "ine"
+  add_foreign_key "ribs", "students"
   add_foreign_key "schoolings", "classes", column: "classe_id"
-  add_foreign_key "schoolings", "students", primary_key: "ine"
-  add_foreign_key "students", "schoolings", column: "current_schooling"
-  add_foreign_key "users", "establishments", primary_key: "uai"
+  add_foreign_key "schoolings", "students"
+  add_foreign_key "students", "schoolings", column: "current_schooling_id"
+  add_foreign_key "users", "establishments"
 end


### PR DESCRIPTION
This is dodgy (re: changing migrations 6 months later) but since we're not live yet we can afford to just blow up the databases and start fresh, which is far more value than trying to maintain integrity over a DB that isn't live yet.