### PR TITLE
store establishment's address

### DIFF
--- a/app/models/establishment.rb
+++ b/app/models/establishment.rb
@@ -27,6 +27,8 @@ class Establishment < ApplicationRecord
   API_MAPPING = {
     "nom_etablissement" => :name,
     "libelle_nature" => :denomination,
+    "adresse_1" => :address_line1,
+    "adresse_2" => :address_line2,
     "code_postal" => :postal_code,
     "nom_commune" => :city,
     "telephone" => :telephone,

--- a/db/migrate/20231023084115_add_adress_lines_to_establishments.rb
+++ b/db/migrate/20231023084115_add_adress_lines_to_establishments.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class AddAdressLinesToEstablishments < ActiveRecord::Migration[7.1]
+  def change
+    change_table :establishments, bulk: true do |t|
+      t.string :address_line1
+      t.string :address_line2
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_16_101548) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_23_084115) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,8 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_16_101548) do
     t.string "email"
     t.boolean "fetching_students", default: false, null: false
     t.boolean "generating_attributive_decisions", default: false, null: false
+    t.string "address_line1"
+    t.string "address_line2"
     t.index ["uai"], name: "index_establishments_on_uai", unique: true
   end
 

--- a/spec/factories/establishments.rb
+++ b/spec/factories/establishments.rb
@@ -8,6 +8,8 @@ FactoryBot.define do
     nature { Faker::Number.between(from: 300, to: 399) }
     postal_code { Faker::Address.postcode }
     city { Faker::Address.city }
+    address_line1 { Faker::Address.street_address }
+    address_line2 { Faker::Address.secondary_address }
 
     trait :with_fim_user do
       after(:create) do |establishment|


### PR DESCRIPTION
J'ai vu dans [la doc](https://data.education.gouv.fr/api/v1/console/datasets/1.0/fr-en-annuaire-education/) qu'on pouvait avoir 3 champs d'adresse, mais que c'était pas le cas dans le mock. Dans le doute j'ai pris les 3.

J'ai créé une méthode `establishment.full_address` qui build les 3-4 lignes qui composent l'adresse, mais comme je sais pas où le foutre dans la DA je me suis arrêté là.