### PR TITLE
pfmp: fix the bulk input

### DIFF
--- a/app/models/classe.rb
+++ b/app/models/classe.rb
@@ -18,10 +18,12 @@ class Classe < ApplicationRecord
   def create_bulk_pfmp(pfmp_params)
     @pfmp = Pfmp.new(pfmp_params)
 
-    return false if @pfmp.invalid?
-
-    students.each do |student|
-      student.current_schooling.pfmps.create!(pfmp_params)
+    Pfmp.transaction do
+      students.each do |student|
+        student.current_schooling.pfmps.create!(pfmp_params)
+      end
+    rescue ActiveRecord::RecordInvalid
+      false
     end
   end
 

--- a/features/gestion_de_pfmp.feature
+++ b/features/gestion_de_pfmp.feature
@@ -23,12 +23,13 @@ Fonctionnalité: Le personnel de direction édite les PFMPs
       | Saisie à valider |               3 | 45,00 € |
 
   Scénario: Le personnel de direction peut rajouter une PFMP pour toute la classe
-    Quand je vais voir la classe "3EMEB"
+    Sachant que je vais voir la classe "3EMEB"
     Et que je clique sur "Saisir une PFMP pour toute la classe"
     Et que je remplis "Date de début" avec "17/03/2023"
     Et que je remplis "Date de fin" avec "20/03/2023"
-    Et que je clique sur "Enregistrer"
+    Quand je clique sur "Enregistrer"
     Alors tous les élèves ont une PFMP du "17/03/2023" au "20/03/2023"
+    Et la page contient "La PFMP a bien été enregistrée"
 
   Scénario: Le personnel de direction est informé d'une erreur de saisie pour toute la classe
     Étant donné que je vais voir la classe "3EMEB"

--- a/features/step_definitions/perdir_steps.rb
+++ b/features/step_definitions/perdir_steps.rb
@@ -83,7 +83,7 @@ Quand("je vais voir la classe {string}") do |label|
 end
 
 Alors("tous les élèves ont une PFMP du {string} au {string}") do |start_date, end_date|
-  expect(@classe.students.all? { |s| s.pfmps.exists?(start_date:, end_date:) })
+  expect(@classe.students.all? { |s| s.pfmps.exists?(start_date:, end_date:) }).to be_truthy
 end
 
 # FIXME: we're relying on global state here via the @student variable


### PR DESCRIPTION
The step used to validate that test was wrong:

`expect(...) <NOTHING>`

which mean we never caught the error, and is a good reminder to USE END-TO-END ASSERTIONS IN END-TO-END TESTS! Check things on the page, not behind the scenes.