### PR TITLE
Invitation deletion

### DIFF
--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class InvitationsController < ApplicationController
-  before_action :check_authorisation
+  before_action :handle_unauthorised
   before_action :set_invitation, only: :destroy
 
   def index
@@ -47,7 +47,7 @@ class InvitationsController < ApplicationController
     @invitation = @etab.invitations.find(params[:id])
   end
 
-  def check_authorisation
+  def handle_unauthorised
     return if current_user.can_authorise?
 
     redirect_back_or_to(

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class InvitationsController < ApplicationController
-  before_action :handle_unauthorised
+  before_action :check_authorised_to_invite
   before_action :set_invitation, only: :destroy
 
   def index
@@ -47,13 +47,13 @@ class InvitationsController < ApplicationController
     @invitation = @etab.invitations.find(params[:id])
   end
 
-  def handle_unauthorised
-    return if current_user.can_authorise?
-
-    redirect_back_or_to(
-      root_path,
-      alert: t("flash.pfmps.not_authorised_to_authorise"),
-      status: :forbidden
-    )
+  def check_authorised_to_invite
+    if current_user.cannot_invite? # rubocop:disable Style/GuardClause
+      redirect_back_or_to(
+        root_path,
+        alert: t("flash.pfmps.not_authorised_to_invite"),
+        status: :forbidden
+      )
+    end
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -48,12 +48,12 @@ class InvitationsController < ApplicationController
   end
 
   def check_authorisation
-    if !current_user.can_authorise?
-      redirect_back_or_to(
-        root_path,
-        alert: t("flash.pfmps.not_authorised_to_authorise"),
-        status: :forbidden
-      ) and return
-    end
+    return if current_user.can_authorise?
+
+    redirect_back_or_to(
+      root_path,
+      alert: t("flash.pfmps.not_authorised_to_authorise"),
+      status: :forbidden
+    )
   end
 end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class InvitationsController < ApplicationController
+  before_action :check_authorisation
+  before_action :set_invitation, only: :destroy
+
   def index
     @invitations = @etab.invitations
 
@@ -19,10 +22,16 @@ class InvitationsController < ApplicationController
     @invitation = Invitation.new(invitation_params)
 
     if @invitation.save
-      redirect_to establishment_invitations_path, notice: "L'email #{@invitation.email} est maintenant autorisé"
+      redirect_to establishment_invitations_path, notice: t("flash.invites.created", email: @invitation.email)
     else
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def destroy
+    @invitation.destroy
+
+    redirect_to establishment_invitations_path(@etab), notice: t("flash.invites.destroyed", email: @invitation.email)
   end
 
   private
@@ -32,5 +41,19 @@ class InvitationsController < ApplicationController
       .require(:invitation)
       .permit(:email)
       .with_defaults(user: current_user, establishment: @etab)
+  end
+
+  def set_invitation
+    @invitation = @etab.invitations.find(params[:id])
+  end
+
+  def check_authorisation
+    if !current_user.can_authorise?
+      redirect_back_or_to(
+        root_path,
+        alert: t("flash.pfmps.not_authorised_to_authorise"),
+        status: :forbidden
+      ) and return
+    end
   end
 end

--- a/app/models/concerns/user_authorisation.rb
+++ b/app/models/concerns/user_authorisation.rb
@@ -12,8 +12,12 @@ module UserAuthorisation
       current_role.dir?
     end
 
-    def can_authorise?
+    def can_invite?
       director?
+    end
+
+    def cannot_invite?
+      !can_invite?
     end
 
     def can_validate?

--- a/app/views/invitations/index.html.haml
+++ b/app/views/invitations/index.html.haml
@@ -1,7 +1,7 @@
 .fr-col-lg-6.fr-col-md-8
   %p.fr-text--lead
-    Vous pouvez autoriser un ou plusieurs collaborateurs à se
-    connecter à APLyPro en renseignant leur email académique. Ils
+    Vous pouvez autoriser un ou plusieurs collaborateurs à accéder
+    à APLyPro en renseignant leur email académique. Ils
     pourront saisir des RIB et des PFMPs.
   %p
     Les personnels de direction restent les seuls à pouvoir à
@@ -10,13 +10,11 @@
 
   = link_to "Autoriser un nouvel email", new_establishment_invitation_path(@etab), class: 'fr-btn fr-btn--primary'
 
-  - if @invitations.none?
-    %p Vous n'avez pas encore autorisé d'accès.
-  - else
-
+  - if @invitations.any?
     .fr-table
       %table
         %tbody
           - @invitations.each do |invite|
             %tr
               %td= invite.email
+              %td= button_to "Retirer l'autorisation", establishment_invitation_path(@etab, invite), method: :delete, class: "fr-btn fr-btn--danger"

--- a/app/views/invitations/index.html.haml
+++ b/app/views/invitations/index.html.haml
@@ -1,21 +1,22 @@
-.fr-col-md-6
+.fr-col-lg-6.fr-col-md-8
   %p.fr-text--lead
     Vous pouvez autoriser un ou plusieurs collaborateurs à se
     connecter à APLyPro en renseignant leur email académique. Ils
     pourront saisir des RIB et des PFMPs.
-
   %p
-    Les personnels de direction restent les seuls à pouvoir valider
-    les PFMPs, éditer les décisions d'attribution et gérer la liste
-    des accès.
+    Les personnels de direction restent les seuls à pouvoir à
+    éditer les décisions d'attribution, valider les PFMPs 
+    pour les envoyer en paiement et gérer la liste des accès.
 
-- if @invitations.none?
-  %p Vous n'avez pas encore autorisé d'accès.
-- else
-  %p Accès autorisés pour votre établissement (#{@etab.uai}) :
+  = link_to "Autoriser un nouvel email", new_establishment_invitation_path(@etab), class: 'fr-btn fr-btn--primary'
 
-  %ul
-    - @invitations.each do |invite|
-      %li= invite.email
+  - if @invitations.none?
+    %p Vous n'avez pas encore autorisé d'accès.
+  - else
 
-= dsfr_link_to "Autoriser un nouvel email", new_establishment_invitation_path(@etab)
+    .fr-table
+      %table
+        %tbody
+          - @invitations.each do |invite|
+            %tr
+              %td= invite.email

--- a/app/views/invitations/index.html.haml
+++ b/app/views/invitations/index.html.haml
@@ -17,4 +17,4 @@
           - @invitations.each do |invite|
             %tr
               %td= invite.email
-              %td= button_to "Retirer l'autorisation", establishment_invitation_path(@etab, invite), method: :delete, class: "fr-btn fr-btn--danger"
+              %td= button_to "Retirer l'accès", establishment_invitation_path(@etab, invite), method: :delete, class: "fr-btn fr-btn--danger"

--- a/app/views/invitations/index.html.haml
+++ b/app/views/invitations/index.html.haml
@@ -18,4 +18,6 @@
             - @invitations.each do |invite|
               %tr
                 %td= invite.email
-                %td= button_to "Retirer l'accès", establishment_invitation_path(@etab, invite), method: :delete, class: "fr-btn fr-btn--danger"
+                %td
+                  .fr-grid-row.fr-grid-row--right
+                    = button_to "Retirer l'accès", establishment_invitation_path(@etab, invite), method: :delete, class: "fr-btn fr-btn--danger"

--- a/app/views/invitations/index.html.haml
+++ b/app/views/invitations/index.html.haml
@@ -1,20 +1,21 @@
-.fr-col-lg-6.fr-col-md-8
-  %p.fr-text--lead
-    Vous pouvez autoriser un ou plusieurs collaborateurs à accéder
-    à APLyPro en renseignant leur email académique. Ils
-    pourront saisir des RIB et des PFMPs.
-  %p
-    Les personnels de direction restent les seuls à pouvoir à
-    éditer les décisions d'attribution, valider les PFMPs 
-    pour les envoyer en paiement et gérer la liste des accès.
+.fr-grid-row
+  .fr-col-lg-6.fr-col-md-8
+    %p.fr-text--lead
+      Vous pouvez autoriser un ou plusieurs collaborateurs à accéder
+      à APLyPro en renseignant leur email académique. Ils
+      pourront saisir des RIB et des PFMPs.
+    %p
+      Les personnels de direction restent les seuls à pouvoir à
+      éditer les décisions d'attribution, valider les PFMPs 
+      pour les envoyer en paiement et gérer la liste des accès.
 
-  = link_to "Autoriser un nouvel email", new_establishment_invitation_path(@etab), class: 'fr-btn fr-btn--primary'
+    = link_to "Autoriser un nouvel email", new_establishment_invitation_path(@etab), class: 'fr-btn fr-btn--primary'
 
-  - if @invitations.any?
-    .fr-table
-      %table
-        %tbody
-          - @invitations.each do |invite|
-            %tr
-              %td= invite.email
-              %td= button_to "Retirer l'accès", establishment_invitation_path(@etab, invite), method: :delete, class: "fr-btn fr-btn--danger"
+    - if @invitations.any?
+      .fr-table
+        %table
+          %tbody
+            - @invitations.each do |invite|
+              %tr
+                %td= invite.email
+                %td= button_to "Retirer l'accès", establishment_invitation_path(@etab, invite), method: :delete, class: "fr-btn fr-btn--danger"

--- a/app/views/invitations/new.html.haml
+++ b/app/views/invitations/new.html.haml
@@ -1,8 +1,4 @@
 .fr-col-md-6
-  %p
-    Entrez ci-dessous l'adresse email académique du personnel que vous
-    souhaitez autoriser.
-
   = form_with model: [@etab, @invitation], builder: DsfrFormBuilder do |form|
     = form.dsfr_error_summary
 

--- a/app/views/invitations/new.html.haml
+++ b/app/views/invitations/new.html.haml
@@ -3,6 +3,13 @@
     Entrez ci-dessous l'adresse email académique du personnel que vous
     souhaitez autoriser.
 
+  = form_with model: [@etab, @invitation], builder: DsfrFormBuilder do |form|
+    = form.dsfr_error_summary
+
+    = form.dsfr_text_field(:email, type: "email", class: 'fr-col-sm-8 fr-col-md-9 fr-col-lg-7')
+
+    = form.submit "Autoriser l'email", { class: 'fr-btn' }
+  
   = dsfr_alert(type: :warning, title: "Seuls les emails académiques sont autorisés", classes: 'fr-my-3w') do
     %p
       L'email renseigné doit impérativement finir par :
@@ -10,11 +17,3 @@
         - Invitation::VALID_DOMAINS.each do |domain|
           %li
             %code= domain
-
-
-  = form_with model: [@etab, @invitation], builder: DsfrFormBuilder do |form|
-    = form.dsfr_error_summary
-
-    = form.dsfr_text_field(:email, type: "email", class: 'fr-col-sm-8 fr-col-md-9 fr-col-lg-7')
-
-    = form.submit "Autoriser l'email", { class: 'fr-btn' }

--- a/app/views/invitations/new.html.haml
+++ b/app/views/invitations/new.html.haml
@@ -1,15 +1,15 @@
-.fr-col-md-6
-  = form_with model: [@etab, @invitation], builder: DsfrFormBuilder do |form|
-    = form.dsfr_error_summary
+= form_with model: [@etab, @invitation], builder: DsfrFormBuilder do |form|
+  = form.dsfr_error_summary
 
-    = form.dsfr_text_field(:email, type: "email", class: 'fr-col-sm-8 fr-col-md-9 fr-col-lg-7')
+  .fr-col-md-6
+    = form.dsfr_text_field(:email, type: "email")
 
     = form.submit "Autoriser l'email", { class: 'fr-btn' }
-  
-  = dsfr_alert(type: :warning, title: "Seuls les emails académiques sont autorisés", classes: 'fr-my-3w') do
-    %p
-      L'email renseigné doit impérativement finir par :
-      %ul
-        - Invitation::VALID_DOMAINS.each do |domain|
-          %li
-            %code= domain
+
+    = dsfr_alert(type: :warning, title: "Seuls les emails académiques sont autorisés", classes: 'fr-my-3w') do
+      %p
+        L'email renseigné doit impérativement finir par :
+        %ul
+          - Invitation::VALID_DOMAINS.each do |domain|
+            %li
+              %code= domain

--- a/app/views/shared/_flash.html.haml
+++ b/app/views/shared/_flash.html.haml
@@ -1,14 +1,13 @@
 - if flash.any?
-  .fr-grid-row
-    .fr-col-md-6.flash.fr-mb-3w
-      - if flash[:notice].present?
-        - if flash[:notice].is_a? String
-          = dsfr_alert(type: :info, title: flash[:notice])
-        - else
-          = dsfr_alert(type: :info, title: flash[:notice]["title"]) { flash[:notice]["content"] }
+  .flash.fr-mb-3w
+    - if flash[:notice].present?
+      - if flash[:notice].is_a? String
+        = dsfr_alert(type: :info, title: flash[:notice])
+      - else
+        = dsfr_alert(type: :info, title: flash[:notice]["title"]) { flash[:notice]["content"] }
 
-      - if flash[:alert].present?
-        - if flash[:alert].is_a? String
-          = dsfr_alert(type: :warning, title: flash[:alert])
-        - else
-          = dsfr_alert(type: :warning, title: flash[:alert]["title"]) { flash[:alert]["content"] }
+    - if flash[:alert].present?
+      - if flash[:alert].is_a? String
+        = dsfr_alert(type: :warning, title: flash[:alert])
+      - else
+        = dsfr_alert(type: :warning, title: flash[:alert]["title"]) { flash[:alert]["content"] }

--- a/app/views/shared/_flash.html.haml
+++ b/app/views/shared/_flash.html.haml
@@ -1,13 +1,14 @@
 - if flash.any?
-  .flash.fr-mb-3w
-    - if flash[:notice].present?
-      - if flash[:notice].is_a? String
-        = dsfr_alert(type: :info, title: flash[:notice])
-      - else
-        = dsfr_alert(type: :info, title: flash[:notice]["title"]) { flash[:notice]["content"] }
+  .fr-grid-row
+    .fr-col-md-6.flash.fr-mb-3w
+      - if flash[:notice].present?
+        - if flash[:notice].is_a? String
+          = dsfr_alert(type: :info, title: flash[:notice])
+        - else
+          = dsfr_alert(type: :info, title: flash[:notice]["title"]) { flash[:notice]["content"] }
 
-    - if flash[:alert].present?
-      - if flash[:alert].is_a? String
-        = dsfr_alert(type: :warning, title: flash[:alert])
-      - else
-        = dsfr_alert(type: :warning, title: flash[:alert]["title"]) { flash[:alert]["content"] }
+      - if flash[:alert].present?
+        - if flash[:alert].is_a? String
+          = dsfr_alert(type: :warning, title: flash[:alert])
+        - else
+          = dsfr_alert(type: :warning, title: flash[:alert]["title"]) { flash[:alert]["content"] }

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -37,7 +37,7 @@
               %li.fr-nav__item
                 %a.fr-nav__link{ href: path, target: "_self", "aria-current" => current_path?(path) ? "page" : nil }
                   = t("menu.#{item}")
-            - if current_user.establishment.present? && current_user.can_authorise?
+            - if current_user.establishment.present? && current_user.can_invite?
               %li.fr-nav__item
                 %a.fr-nav__link{ href: establishment_invitations_path(@etab), target: "_self", "aria-current" => current_path?(establishment_invitations_path(@etab)) ? "page" : nil }
                   = t("menu.invitations")

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,8 +2,12 @@ fr:
   year:
     "Année scolaire %{start_year} - %{end_year}"
   flash:
+    invites:
+      created: L'email %{email} est maintenant autorisé à accéder à APLyPro
+      destroyed: L'email %{email} n'est plus autorisé à accéder à APLyPro
     pfmps:
       not_authorised_to_validate: Seuls les personnels de direction peuvent valider les PFMPs
+      not_authorised_to_authorise: Seuls les personnels de direction peuvent gérer les accès
       destroyed: La PFMP de %{name} a bien été supprimée
       validated: La PFMP de %{name} a bien été validée
   helpers:
@@ -72,7 +76,7 @@ fr:
     titles:
       invitations:
         index: Gestion des accès
-        new: Autoriser un email
+        new: Autoriser un email à accéder à APLyPro
       home:
         home: Accueil
         login: Connexion à APLyPro

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -7,7 +7,7 @@ fr:
       destroyed: L'email %{email} n'est plus autorisé à accéder à APLyPro
     pfmps:
       not_authorised_to_validate: Seuls les personnels de direction peuvent valider les PFMPs
-      not_authorised_to_authorise: Seuls les personnels de direction peuvent gérer les accès
+      not_authorised_to_invite: Seuls les personnels de direction peuvent gérer les accès
       destroyed: La PFMP de %{name} a bien été supprimée
       validated: La PFMP de %{name} a bien été validée
   helpers:

--- a/features/invitations.feature
+++ b/features/invitations.feature
@@ -14,3 +14,8 @@ Fonctionnalité: Gestion des accès à l'application
   Scénario: Je ne peux pas inviter que des emails académiques
     Lorsque j'autorise "marie.curie@gmail.com" à rejoindre l'application
     Alors la page contient "seuls les emails académiques"
+
+  Scénario: Je peux supprimer une invitation
+    Lorsque j'autorise "marie.curie@education.gouv.fr" à rejoindre l'application
+    Et que je clique sur "Retirer l'accès"
+    Alors la page contient "n'est plus autorisé à accéder à APLyPro"

--- a/features/invitations.feature
+++ b/features/invitations.feature
@@ -8,7 +8,7 @@ Fonctionnalité: Gestion des accès à l'application
 
   Scénario: Je peux inviter une nouvelle personne sur l'application
     Lorsque j'autorise "marie.curie@education.gouv.fr" à rejoindre l'application
-    Lorsque je vais consulter la liste des invitations
+    Lorsque je consulte la liste des invitations
     Alors la page contient "marie.curie@education.gouv.fr"
 
   Scénario: Je ne peux pas inviter que des emails académiques
@@ -17,5 +17,6 @@ Fonctionnalité: Gestion des accès à l'application
 
   Scénario: Je peux supprimer une invitation
     Lorsque j'autorise "marie.curie@education.gouv.fr" à rejoindre l'application
+    Et que je consulte la liste des invitations
     Et que je clique sur "Retirer l'accès"
-    Alors la page contient "n'est plus autorisé à accéder à APLyPro"
+    Alors la page contient "marie.curie@education.gouv.fr n'est plus autorisé à accéder à APLyPro"

--- a/features/profil_autorisé.feature
+++ b/features/profil_autorisé.feature
@@ -22,3 +22,15 @@ Fonctionnalité: Gestion des accès à l'application
     Lorsque je me connecte en tant que personnel MENJ
     Et que je passe l'écran d'accueil
     Alors la page ne contient pas "Gestion des accès"
+
+  Scénario: Je ne peux plus me connecter à l'application en tant qu'invité si mon accès a été supprimé
+    Lorsque je me connecte en tant que personnel MENJ
+    Et que je me déconnecte
+    Et que je suis un personnel MENJ directeur de l'établissement "DINUM"
+    Et que je me connecte en tant que personnel MENJ
+    Et que je consulte la liste des invitations
+    Et que je clique sur "Retirer l'accès"
+    Et que je me déconnecte
+    Quand je suis un personnel MENJ de l'établissement "DINUM" avec l'email "marie.curie@education.gouv.fr"
+    Et que je me connecte en tant que personnel MENJ
+    Alors la page contient "Votre adresse e-mail n'est pas reconnue"

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -12,7 +12,7 @@ def make_fim_hash(name:, email:, raw_info:)
   OmniAuth::AuthHash.new(
     {
       provider: "fim",
-      uid: Faker::Alphanumeric.alpha(number: 10),
+      uid: email,
       credentials: {
         token: "test token"
       },

--- a/features/step_definitions/perdir_steps.rb
+++ b/features/step_definitions/perdir_steps.rb
@@ -130,14 +130,14 @@ end
 
 Sachantque("j'autorise {string} à rejoindre l'application") do |email|
   steps %(
-    Quand je vais consulter la liste des invitations
+    Quand je consulte la liste des invitations
     Et que je clique sur "Autoriser un nouvel email"
     Et que je remplis "Email" avec "#{email}"
     Et que je clique sur "Autoriser l'email"
   )
 end
 
-Lorsque("je vais consulter la liste des invitations") do
+Lorsque("je consulte la liste des invitations") do
   steps %(
     Quand je me rends sur la page d'accueil
     Et que je clique sur "Gestion des accès"


### PR DESCRIPTION
Il y a un truc qui me gène avec l'alerte en cas d'échec d'un formulaire :

![Screenshot from 2023-10-30 14-37-45](https://github.com/betagouv/aplypro/assets/6117264/689b020c-1239-4029-9f8f-804b89d26bc3)

Son `fr-col-md-6` la rend très petite quand on est déjà dans un conteneur `fr-col-md-6`. Perso je mettrai éventuellement une largeur max à nos alertes, mais je ne lui mettrai pas de largeur en colonnes comme ça, par ce que ça dépend trop du contexte dans lequel on l'ajoute.

Aussi on perd le breadcrumb, mais ça c'est moins grave.