### PR TITLE
user roles: add a primary key

### DIFF
--- a/db/migrate/20231030135955_add_primary_key_to_establishment_user_roles.rb
+++ b/db/migrate/20231030135955_add_primary_key_to_establishment_user_roles.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddPrimaryKeyToEstablishmentUserRoles < ActiveRecord::Migration[7.1]
+  def change
+    change_table :establishment_user_roles do |t|
+      t.column :id, :primary_key
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_10_23_084115) do
+ActiveRecord::Schema[7.1].define(version: 2023_10_30_135955) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -53,7 +53,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_10_23_084115) do
     t.index ["mef_id"], name: "index_classes_on_mef_id"
   end
 
-  create_table "establishment_user_roles", id: false, force: :cascade do |t|
+  create_table "establishment_user_roles", force: :cascade do |t|
     t.bigint "establishment_id", null: false
     t.bigint "user_id", null: false
     t.bigint "granted_by_id"


### PR DESCRIPTION
We initially went with the `create_join_table` helper from ActiveRecord which creates an ID-less table[1] ; that's problematic because we've got extra attributes on the table which might need updating sooner or later.

[1]: https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/SchemaStatements.html#method-i-create_join_table