### PR TITLE
pfmp: make the authorisation check more explicit

### DIFF
--- a/app/controllers/pfmps_controller.rb
+++ b/app/controllers/pfmps_controller.rb
@@ -2,7 +2,7 @@
 
 class PfmpsController < ApplicationController
   before_action :authenticate_user!
-  before_action :check_authorisation, only: %i[validate validate_all]
+  before_action :check_authorised_to_validate, only: %i[validate validate_all]
   before_action :set_classe, :set_student, :set_breadcrumbs, except: :validate_all
   before_action :set_pfmp, only: %i[show edit update validate confirm_deletion destroy]
 
@@ -112,13 +112,13 @@ class PfmpsController < ApplicationController
     )
   end
 
-  def check_authorisation
-    return if current_user.can_validate?
-
-    redirect_back_or_to(
-      root_path,
-      alert: t("flash.pfmps.not_authorised_to_validate"),
-      status: :forbidden
-    )
+  def check_authorised_to_validate
+    if current_user.cannot_validate? # rubocop:disable Style/GuardClause
+      redirect_back_or_to(
+        root_path,
+        alert: t("flash.pfmps.not_authorised_to_validate"),
+        status: :forbidden
+      )
+    end
   end
 end

--- a/app/models/concerns/user_authorisation.rb
+++ b/app/models/concerns/user_authorisation.rb
@@ -20,6 +20,10 @@ module UserAuthorisation
       director?
     end
 
+    def cannot_validate?
+      !can_validate?
+    end
+
     def can_generate_attributive_decisions?
       director?
     end


### PR DESCRIPTION
Since we're also checking authorisation in other places (ex: invitations), it makes sense to disambiguate here. Also avoid the guard-clause style for the check because

```
def check_authorisation
  return if you can validate

  redirect
end
```

is a lot more confusing than

```
def check_authorisation
  if you cannot validate
    send you back
  end
end
```

that's why you're not human, Rubocop