### PR TITLE
disable DA button for launch

### DIFF
--- a/app/views/classes/_attributive_decisions_panel.html.haml
+++ b/app/views/classes/_attributive_decisions_panel.html.haml
@@ -10,10 +10,11 @@
     %p Les décisions d'attribution sont en train d'être éditées, veuillez rafraichir la page dans quelques minutes. Vous pouvez commencer à remplir des coordonnées bancaires ou des PFMPs pendant ce temps.
 - else
   %ul.fr-btns-group
-    - if @etab.attributive_decisions_zip.attached?
-      %li= link_to "Télécharger l'ensemble des décisions d'attribution", url_for(@etab.attributive_decisions_zip), class: 'fr-btn fr-btn--primary fr-mb-0', target: :download
-    - else
-      - if current_user.can_generate_attributive_decisions?
-        %li= button_to "Éditer les décisions d'attribution", establishment_create_attributive_decisions_path(@etab), class: 'fr-btn fr-btn--primary fr-mb-0'
-      - else
-        %li= button_to "Vous n'avez pas le droit d'éditer les décisions d'attribution", "#", class: 'fr-btn fr-btn--primary fr-mb-0', disabled: true
+    %li= button_to "L'édition des décisions d'attribution n'est pas encore disponible", "#", class: 'fr-btn fr-btn--primary fr-mb-0', disabled: true
+    -# - if @etab.attributive_decisions_zip.attached?
+    -#   %li= link_to "Télécharger l'ensemble des décisions d'attribution", url_for(@etab.attributive_decisions_zip), class: 'fr-btn fr-btn--primary fr-mb-0', target: :download
+    -# - else
+      -# - if current_user.can_generate_attributive_decisions?
+      -#   %li= button_to "Éditer les décisions d'attribution", establishment_create_attributive_decisions_path(@etab), class: 'fr-btn fr-btn--primary fr-mb-0'
+      -# - else
+      -#   %li= button_to "Vous n'avez pas le droit d'éditer les décisions d'attribution", "#", class: 'fr-btn fr-btn--primary fr-mb-0', disabled: true

--- a/features/décisions_d_attributions.feature
+++ b/features/décisions_d_attributions.feature
@@ -1,18 +1,18 @@
 # language: fr
 
 Fonctionnalité: Le personnel de direction peut éditer les décisions d'attribution
-  Contexte:
-    Sachant que l'API SYGNE renvoie une liste d'élèves
-    Et que je suis un personnel MENJ directeur de l'établissement "DINUM"
-    Et que je me connecte en tant que personnel MENJ
-    Et qu'il y a une élève "Marie Curie" au sein de la classe "2NDEB" pour une formation "Développement"
-    Et que je passe l'écran d'accueil
-    Alors le panneau "Décisions d'attribution" contient un compteur à "0 / 1"
+  # Contexte:
+  #   Sachant que l'API SYGNE renvoie une liste d'élèves
+  #   Et que je suis un personnel MENJ directeur de l'établissement "DINUM"
+  #   Et que je me connecte en tant que personnel MENJ
+  #   Et qu'il y a une élève "Marie Curie" au sein de la classe "2NDEB" pour une formation "Développement"
+  #   Et que je passe l'écran d'accueil
+  #   Alors le panneau "Décisions d'attribution" contient un compteur à "0 / 1"
 
-  Scénario: Le personnel de direction peut lancer l'édition des décisions d'attribution
-    Quand je clique sur "Éditer les décisions d'attribution"
-    Alors la page contient "Édition des décisions d'attribution en cours"
-    Quand toutes les tâches de fond sont terminées
-    Et que je rafraîchis la page
-    Alors la page contient "Télécharger l'ensemble des décisions d'attribution"
-    Alors le panneau "Décisions d'attribution" contient un compteur à "1 / 1"
+  # Scénario: Le personnel de direction peut lancer l'édition des décisions d'attribution
+  #   Quand je clique sur "Éditer les décisions d'attribution"
+  #   Alors la page contient "Édition des décisions d'attribution en cours"
+  #   Quand toutes les tâches de fond sont terminées
+  #   Et que je rafraîchis la page
+  #   Alors la page contient "Télécharger l'ensemble des décisions d'attribution"
+  #   Alors le panneau "Décisions d'attribution" contient un compteur à "1 / 1"


### PR DESCRIPTION
Pour avoir le bouton ready si on décide de disable l'édition de DA pour le lancement, en attendant d'avoir l'adresse des élèves dedans.