### PR TITLE
auth: fix an error mismatch

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -22,7 +22,7 @@ module Users
         check_responsibilites!
       rescue IdentityMappers::Errors::EmptyResponsibilitiesError
         check_access_list!
-      rescue IdentityMappers::Errors::NoDelegationsError
+      rescue IdentityMappers::Errors::NotAuthorisedError
         raise IdentityMappers::Errors::NoAccessFound
       end
 


### PR DESCRIPTION
This error was renamed a while ago but we didn't update the check, which means it was handled gracefully still, but not with the right message.