### PR TITLE
auth: add some tests and a way to override the FIM attributes

### DIFF
--- a/app/controllers/concerns/developer_oidc.rb
+++ b/app/controllers/concerns/developer_oidc.rb
@@ -76,9 +76,17 @@ module DeveloperOidc
     line = ["#{uai}$UAJ$PU$N$T3$LYC$340"]
 
     if provider(attrs) == :fim
-      { FrEduRneResp: line }
+      {
+        FrEduRneResp: line,
+        FrEduFonctAdm: "DIR"
+      }
     else
-      { attributes: { fr_edu_rne_resp: line } }
+      {
+        attributes: {
+          fr_edu_rne_resp: line,
+          fr_edu_fonct_adm: "DIR"
+        }
+      }
     end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -75,7 +75,7 @@ module Users
     end
 
     def save_roles!
-      @mapper.establishments.each do |e|
+      @mapper.establishments_in_responsibility.each do |e|
         e.save! unless e.persisted?
 
         EstablishmentUserRole
@@ -125,13 +125,13 @@ module Users
     end
 
     def async_fetch_students!
-      jobs = @mapper.establishments.map { |e| FetchStudentsJob.new(e) }
+      jobs = @mapper.establishments_in_responsibility.map { |e| FetchStudentsJob.new(e) }
 
       ActiveJob.perform_all_later(jobs)
     end
 
     def fetch_establishments!
-      @mapper.establishments.each { |e| FetchEstablishmentJob.perform_now(e) }
+      @mapper.establishments_in_responsibility.each { |e| FetchEstablishmentJob.perform_now(e) }
     end
 
     def clear_previous_establishment!

--- a/app/models/concerns/identity_mappers/base.rb
+++ b/app/models/concerns/identity_mappers/base.rb
@@ -12,17 +12,29 @@ module IdentityMappers
       @attributes = normalize(attributes)
     end
 
+    def normalize(attributes)
+      attributes
+    end
+
     def map_responsibility(line)
       FREDURNERESP_MAPPING.zip(line.split("$")).to_h
     end
 
+    def map_establishment(line)
+      FREDURNE_MAPPING.zip(line.split("$")).to_h
+    end
+
     def responsibilities
-      return [] if attributes["FrEduRneResp"].blank?
+      return [] if attributes["FrEduRneResp"].blank? || !director?
 
       Array(attributes["FrEduRneResp"])
         .reject { |line| no_value?(line) }
         .map    { |line| map_responsibility(line) }
         .filter { |line| relevant?(line) }
+    end
+
+    def director?
+      attributes["FrEduFonctAdm"] == "DIR"
     end
 
     def no_value?(line)
@@ -33,10 +45,6 @@ module IdentityMappers
       ACCEPTED_ESTABLISHMENT_TYPES.include?(attrs[:tty_code])
     end
 
-    def map_establishment(line)
-      FREDURNE_MAPPING.zip(line.split("$")).to_h
-    end
-
     def authorised_establishments_for(email)
       return [] if attributes["FrEduRne"].blank?
 
@@ -44,10 +52,10 @@ module IdentityMappers
         .reject     { |line| no_value?(line) }
         .map        { |line| map_establishment(line) }
         .filter_map { |attrs| Establishment.find_by(uai: attrs[:uai]) }
-        .select { |etab| etab.invites?(email) }
+        .select     { |establishment| establishment.invites?(email) }
     end
 
-    def establishments
+    def establishments_in_responsibility
       responsibilities
         .pluck(:uai)
         .map { |uai| Establishment.find_or_create_by!(uai: uai) }

--- a/app/models/concerns/identity_mappers/cas.rb
+++ b/app/models/concerns/identity_mappers/cas.rb
@@ -8,6 +8,7 @@ module IdentityMappers
         .tap do |attrs|
         attrs["FrEduRneResp"] = attrs.delete("fr_edu_rne_resp")
         attrs["FrEduRne"] = attrs.delete("fr_edu_rne")
+        attrs["FrEduFonctAdm"] = attrs.delete("fr_edu_fonct_adm")
       end
     end
   end

--- a/app/models/concerns/identity_mappers/fim.rb
+++ b/app/models/concerns/identity_mappers/fim.rb
@@ -5,5 +5,13 @@ module IdentityMappers
     def normalize(attributes)
       attributes
     end
+
+    def responsibilities
+      aplypro_responsibilities + super
+    end
+
+    def aplypro_responsibilities
+      Array(attributes["AplyproResp"]).compact.map { |u| { uai: u } }
+    end
   end
 end

--- a/features/premiere_connexion.feature
+++ b/features/premiere_connexion.feature
@@ -43,3 +43,14 @@ Fonctionnalité: Le personnel de direction se connecte
     Et que l'accès est limité aux UAIs "456"
     Quand je me connecte en tant que personnel MENJ
     Alors la page contient "Accès restreint"
+
+  # Les personnels de la Mer passent par la FIM mais n'ont pas les
+  # attributs "FrEduRneResp" et "FrEduFonctAdm" renseignés, c'est un
+  # choix volontaire du côté de la FIM. Pour palier au problème nous
+  # avons un attribut spécifique que nous pouvons renseigner pour
+  # forcer l'association entre le profil et un établissement en
+  # responsabilité.
+  Scénario: Un personnel de direction de la MER peut être introduit dans l'application
+    Sachant que je suis un personnel MENJ avec un accès spécifique pour l'UAI "456"
+    Quand je me connecte en tant que personnel MENJ
+    Alors la page contient "Connexion réussie"

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -63,7 +63,8 @@ Sachantque("je suis un personnel MASA directeur de l'établissement {string}") d
     name: Faker::Name.name,
     email: Faker::Internet.email,
     raw_info: {
-      fr_edu_rne_resp: make_fredurneresp(uai)
+      fr_edu_rne_resp: make_fredurneresp(uai),
+      fr_edu_fonct_adm: "DIR"
     }
   )
 end
@@ -82,7 +83,18 @@ Sachantque("je suis un personnel MENJ directeur de l'établissement {string}") d
     name: Faker::Name.name,
     email: Faker::Internet.email,
     raw_info: {
-      FrEduRneResp: uais.map { |u| make_fredurneresp(u) }
+      FrEduRneResp: uais.map { |u| make_fredurneresp(u) },
+      FrEduFonctAdm: "DIR"
+    }
+  )
+end
+
+Sachantque("je suis un personnel MENJ avec un accès spécifique pour l'UAI {string}") do |uai|
+  OmniAuth.config.mock_auth[:fim] = make_fim_hash(
+    name: Faker::Name.name,
+    email: Faker::Internet.email,
+    raw_info: {
+      AplyproResp: uai
     }
   )
 end

--- a/spec/models/concerns/identity_mappers/base_spec.rb
+++ b/spec/models/concerns/identity_mappers/base_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe IdentityMappers::Base do
+  let(:attributes) { {} }
+
+  describe "#responsibilities" do
+    context "when there is a FrEduRneResp" do
+      subject(:result) { described_class.new(attributes).responsibilities }
+
+      let(:fredurneresp) { ["0441550W$UAJ$PU$N$T3$LYC$340"] }
+      let(:fredufonctadm) { "DIR" }
+
+      let(:attributes) do
+        {
+          "FrEduRneResp" => fredurneresp,
+          "FrEduFonctAdm" => fredufonctadm
+        }
+      end
+
+      context "when it's a not the right kind of school" do
+        let(:fredurneresp) { "0441550W$UAJ$PU$N$T3$CLG$340" }
+
+        it { is_expected.to be_empty }
+      end
+
+      context "when it's the proper kind of school" do
+        it { is_expected.to contain_exactly a_hash_including(uai: "0441550W") }
+      end
+
+      context "when the administration function is not DIR" do
+        let(:fredufonctadm) { "ADM" }
+
+        it { is_expected.to be_empty }
+      end
+
+      context "when the FrEduRneResp value is plain" do
+        let(:fredurneresp) { "0441550W$UAJ$PU$N$T3$LYC$340" }
+
+        it { is_expected.not_to be_empty }
+      end
+    end
+
+    context "when there is no FrEduRneResp" do
+      it "is empty" do
+        expect(described_class.new(attributes).responsibilities).to be_empty
+      end
+    end
+  end
+end

--- a/spec/models/concerns/identity_mappers/fim_spec.rb
+++ b/spec/models/concerns/identity_mappers/fim_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+RSpec.describe IdentityMappers::Fim do
+  subject(:mapper) { described_class.new(attributes) }
+
+  let(:attributes) { {} }
+
+  describe "#responsibilities" do
+    subject(:result) { mapper.responsibilities }
+
+    context "when the AplyproResp attribute is present" do
+      let(:attributes) { { "AplyproResp" => "123" } }
+
+      it { is_expected.to include a_hash_including(uai: "123") }
+    end
+  end
+end


### PR DESCRIPTION
Some of our personnel (Secrétaire d'État chargé de la Mer) will not have their attributes (like FrEduRneResp) setup correctly, because the FIM auth won't let them.

To remedy that, add a custom "AplyproResp" attribute that can be used to add some UAIs in responsbility for a given user account. This allows us to augment these users and let them access APLyPro despite the missing values.