### PR TITLE
schooling: add a current scope and use it to fix bulk PFMP creation

### DIFF
--- a/app/models/classe.rb
+++ b/app/models/classe.rb
@@ -19,8 +19,8 @@ class Classe < ApplicationRecord
     @pfmp = Pfmp.new(pfmp_params)
 
     Pfmp.transaction do
-      students.each do |student|
-        student.current_schooling.pfmps.create!(pfmp_params)
+      schoolings.current.each do |schooling|
+        schooling.pfmps.create!(pfmp_params)
       end
     rescue ActiveRecord::RecordInvalid
       false

--- a/app/models/schooling.rb
+++ b/app/models/schooling.rb
@@ -11,6 +11,8 @@ class Schooling < ApplicationRecord
   has_one :mef, through: :classe
   has_one :establishment, through: :classe
 
+  scope :current, -> { where(end_date: nil) }
+
   after_create :replace_former_schooling
 
   def replace_former_schooling

--- a/spec/models/schooling_spec.rb
+++ b/spec/models/schooling_spec.rb
@@ -55,4 +55,20 @@ RSpec.describe Schooling do
       end
     end
   end
+
+  describe ".current" do
+    subject { described_class.current }
+
+    context "when the schooling is over" do
+      let(:schooling) { create(:schooling, :closed) }
+
+      it { is_expected.not_to include schooling }
+    end
+
+    context "when the schooling is active" do
+      let(:schooling) { create(:schooling) }
+
+      it { is_expected.to include schooling }
+    end
+  end
 end


### PR DESCRIPTION
We might have classes with leftover schoolings from students who left, so ignore these when trying to create bulk PFMPs.