### PR TITLE
Auth fixes

### DIFF
--- a/app/models/concerns/identity_mappers/fim.rb
+++ b/app/models/concerns/identity_mappers/fim.rb
@@ -6,12 +6,12 @@ module IdentityMappers
       attributes
     end
 
-    def responsibilities
+    def responsibility_uais
       aplypro_responsibilities + super
     end
 
     def aplypro_responsibilities
-      Array(attributes["AplyproResp"]).compact.map { |u| { uai: u } }
+      Array(attributes["AplyproResp"]).compact
     end
   end
 end

--- a/features/premiere_connexion.feature
+++ b/features/premiere_connexion.feature
@@ -66,6 +66,16 @@ Fonctionnalité: Le personnel de direction se connecte
     Quand je me connecte en tant que personnel MENJ
     Alors la page contient "Bienvenue sur APLyPro"
 
+  Scénario: Un personnel du MENJ dans un UAI pilote peut-être refusé
+    Sachant que l'accès est limité aux UAIs "123"
+    Et que je suis un personnel MENJ directeur de l'établissement "123"
+    Et que je me connecte en tant que personnel MENJ
+    Et que j'autorise "louis.pasteur@education.gouv.fr" à rejoindre l'application
+    Et que je me déconnecte
+    Et que je suis un personnel MENJ de l'établissement "123" avec l'email "jean.michel@education.gouv.fr"
+    Quand je me connecte en tant que personnel MENJ
+    Alors la page affiche une erreur d'authentification
+
   # Les personnels de la Mer passent par la FIM mais n'ont pas les
   # attributs "FrEduRneResp" et "FrEduFonctAdm" renseignés, c'est un
   # choix volontaire du côté de la FIM. Pour palier au problème nous

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -94,7 +94,7 @@ Sachantque("je suis un personnel MENJ avec un accès spécifique pour l'UAI {str
     name: Faker::Name.name,
     email: Faker::Internet.email,
     raw_info: {
-      AplyproResp: uai
+      "AplyproResp" => uai
     }
   )
 end

--- a/spec/factories/auth.rb
+++ b/spec/factories/auth.rb
@@ -27,6 +27,6 @@ FactoryBot.define do
       tna_code { "340" }
     end
 
-    initialize_with { [uai, type, category, function, activity, tna_sym, tty_code, tna_code].join("$") }
+    initialize_with { [uai, type, category, function, uaj, tna_sym, tty_code, tna_code].join("$") }
   end
 end

--- a/spec/factories/auth.rb
+++ b/spec/factories/auth.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :fredurneresp, class: "String" do
+    transient do
+      uai { "123" }
+      type { "UAJ" }
+      category { "PU" }
+      activity { "N" }
+      tna_sym { "T3" }
+      tty_code { "LYC" }
+      tna_code { "340" }
+    end
+
+    initialize_with { [uai, type, category, activity, tna_sym, tty_code, tna_code].join("$") }
+  end
+
+  factory :fredurne, class: "String" do
+    transient do
+      uai { "123" }
+      type { "UAJ" }
+      category { "PU" }
+      function { "ADM" }
+      uaj { "456" }
+      tna_sym { "T3" }
+      tty_code { "LYC" }
+      tna_code { "340" }
+    end
+
+    initialize_with { [uai, type, category, function, activity, tna_sym, tty_code, tna_code].join("$") }
+  end
+end

--- a/spec/models/concerns/identity_mappers/base_spec.rb
+++ b/spec/models/concerns/identity_mappers/base_spec.rb
@@ -1,30 +1,53 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe IdentityMappers::Base do
-  let(:attributes) { {} }
+  let(:mapper) { described_class.new(attributes) }
+  let(:fredurneresp) { build(:fredurneresp, uai: "dir") }
+  let(:fredufonctadm) { "DIR" }
+  let(:fredurne) { [build(:fredurne, uai: "normal")] }
 
-  describe "#responsibilities" do
+  let(:attributes) do
+    {
+      "FrEduRneResp" => fredurneresp,
+      "FrEduRne" => fredurne,
+      "FrEduFonctAdm" => fredufonctadm
+    }
+  end
+
+  describe "#all_indicated_uais" do
+    subject(:result) { mapper.all_indicated_uais }
+
+    it { is_expected.to contain_exactly "normal", "dir" }
+
+    context "when there are irrelevant establishments" do
+      let(:fredurne) { [build(:fredurne, uai: "normal"), build(:fredurne, uai: "normal wrong", tty_code: "CLG")] }
+      let(:fredurneresp) { [build(:fredurneresp, uai: "dir"), build(:fredurneresp, uai: "dir wrong", tty_code: "CLG")] }
+
+      it { is_expected.not_to include "normal wrong", "dir wrong" }
+    end
+
+    context "when there are no values" do
+      let(:fredurneresp) { ["X"] }
+      let(:fredurne) { ["X"] }
+
+      it { is_expected.to be_empty }
+    end
+  end
+
+  describe "#responsibility_uais" do
     context "when there is a FrEduRneResp" do
-      subject(:result) { described_class.new(attributes).responsibilities }
-
-      let(:fredurneresp) { ["0441550W$UAJ$PU$N$T3$LYC$340"] }
-      let(:fredufonctadm) { "DIR" }
-
-      let(:attributes) do
-        {
-          "FrEduRneResp" => fredurneresp,
-          "FrEduFonctAdm" => fredufonctadm
-        }
-      end
+      subject(:result) { mapper.responsibility_uais }
 
       context "when it's a not the right kind of school" do
-        let(:fredurneresp) { "0441550W$UAJ$PU$N$T3$CLG$340" }
+        let(:fredurneresp) { [build(:fredurneresp, uai: "dir wrong", tty_code: "CLG")] }
 
         it { is_expected.to be_empty }
       end
 
       context "when it's the proper kind of school" do
-        it { is_expected.to contain_exactly a_hash_including(uai: "0441550W") }
+        it { is_expected.to contain_exactly "dir" }
       end
 
       context "when the administration function is not DIR" do
@@ -42,7 +65,9 @@ RSpec.describe IdentityMappers::Base do
 
     context "when there is no FrEduRneResp" do
       it "is empty" do
-        expect(described_class.new(attributes).responsibilities).to be_empty
+        attributes.delete("FrEduRneResp")
+
+        expect(described_class.new(attributes).responsibility_uais).to be_empty
       end
     end
   end

--- a/spec/models/concerns/identity_mappers/fim_spec.rb
+++ b/spec/models/concerns/identity_mappers/fim_spec.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 RSpec.describe IdentityMappers::Fim do
   subject(:mapper) { described_class.new(attributes) }
 
-  let(:attributes) { {} }
+  let(:fredurneresp) { [build(:fredurneresp, uai: "456")] }
+  let(:attributes) { { "FrEduRneResp" => fredurneresp, "FrEduFonctAdm" => "DIR" } }
 
   describe "#responsibilities" do
-    subject(:result) { mapper.responsibilities }
+    subject(:result) { mapper.responsibility_uais }
 
     context "when the AplyproResp attribute is present" do
-      let(:attributes) { { "AplyproResp" => "123" } }
+      before do
+        attributes.merge!({ "AplyproResp" => "123" })
+      end
 
-      it { is_expected.to include a_hash_including(uai: "123") }
+      it { is_expected.to contain_exactly "456", "123" }
     end
   end
 end


### PR DESCRIPTION
> Previously we weren't calculating properly: the user's UAIs were valid
responsibilities we'd found, and valid establishments **for which you
had authorisation** from your boss. This means that if you were in the
proper UAI, you'd still get the "we're in private beta" error, whereas
you should get the "no access found for you" error.
>
> This fixes it by introducing plainer methods to deal with UAIs we find
in the identity vector.

