### PR TITLE
auth: save users even if they can't get through

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -18,6 +18,8 @@ module Users
     def oidc
       parse_identity
 
+      @user.save!
+
       check_limited_access!
 
       begin
@@ -30,7 +32,7 @@ module Users
         end
       end
 
-      check_user!
+      log_user_in!
       save_roles!
       async_fetch_students!
       fetch_establishments!
@@ -95,9 +97,7 @@ module Users
       end
     end
 
-    def check_user!
-      @user.save!
-
+    def log_user_in!
       sign_in(@user)
       Sentry.set_user(id: @user.id)
     end

--- a/features/premiere_connexion.feature
+++ b/features/premiere_connexion.feature
@@ -29,7 +29,7 @@ Fonctionnalité: Le personnel de direction se connecte
     Sachant que je suis un personnel MENJ de l'établissement "123"
     Quand je me connecte en tant que personnel MENJ
     Alors la page affiche une erreur d'authentification
-    Et il n'y a pas de personnel de direction enregistré dans la base de données
+    Mais il y a un compte utilisateur enregistré
 
   Scénario: Un personnel de direction du MENJ peut se reconnecter sans problèmes
     Sachant que je suis un personnel MENJ directeur de l'établissement "123"

--- a/features/step_definitions/perdir_steps.rb
+++ b/features/step_definitions/perdir_steps.rb
@@ -121,8 +121,8 @@ Quand("je renseigne {int} jours pour la dernière PFMP de {string}") do |days, n
   )
 end
 
-Alors("il n'y a pas de personnel de direction enregistré dans la base de données") do
-  expect(User.count).to eq 0
+Alors("il y a un compte utilisateur enregistré") do
+  expect(User.count).to eq 1
 end
 
 Quand("je n'ai pas encore vu l'écran d'accueil") do


### PR DESCRIPTION
Piggy-backing the previous PR storing OIDC attributes into the User model, we do want to save these as soon as we come back from the auth so we can debug them ourselves.