### PR TITLE
auth: fix a failing spec for MASA

### DIFF
--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -23,7 +23,7 @@ def make_cas_hash(name:, email:, raw_info:)
   OmniAuth::AuthHash.new(
     {
       provider: "masa",
-      uid: Faker::Alphanumeric.alpha(number: 10),
+      uid: email,
       credentials: {
         token: "test token"
       },


### PR DESCRIPTION
We were using randomly-generated UIDs for the MASA fake auth hash, which means faking the auth twice for the same email doesn't work: the UID is different and our User find_or_initialize_by call uses the provider AND the UID, which meant two accounts, one email, no-go.