### PR TITLE
maintenance: also handle a wrong maintenance page

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -30,6 +30,8 @@ class HomeController < ApplicationController
   end
 
   def maintenance
+    redirect_to root_path and return if !maintenance_mode?
+
     @msg = ENV.fetch("APLYPRO_MAINTENANCE_REASON")
   end
 


### PR DESCRIPTION
We were never supposed to reach the maintenance page if we're not in maintenance but someone has probably bookmarked the page cause it keeps popping up.