### PR TITLE
fregata: ensure the API bubbles up 401s

### DIFF
--- a/app/api/student_api/fregata.rb
+++ b/app/api/student_api/fregata.rb
@@ -32,6 +32,7 @@ module StudentApi
     def client
       @client ||= Faraday.new do |f|
         f.response :json
+        f.response :raise_error
       end
     end
 

--- a/app/jobs/fetch_students_job.rb
+++ b/app/jobs/fetch_students_job.rb
@@ -3,6 +3,8 @@
 class FetchStudentsJob < ApplicationJob
   queue_as :default
 
+  retry_on Faraday::UnauthorizedError, wait: 1.second, attempts: 5
+
   around_perform do |job, block|
     establishment = job.arguments.first
 

--- a/spec/api/student_api/fregata_spec.rb
+++ b/spec/api/student_api/fregata_spec.rb
@@ -33,4 +33,15 @@ describe StudentApi::Fregata do
       .to have_requested(:get, api.endpoint)
       .with(query: { rne: establishment.uai, anneeScolaireId: 44 })
   end
+
+  context "when the API returns a 401 error" do
+    before do
+      stub_request(:get, /#{api.endpoint}/)
+        .to_return(status: 401, body: "invalid signature", headers: {})
+    end
+
+    it "raises" do
+      expect { api.fetch! }.to raise_error Faraday::UnauthorizedError
+    end
+  end
 end

--- a/spec/jobs/fetch_students_job_spec.rb
+++ b/spec/jobs/fetch_students_job_spec.rb
@@ -3,6 +3,8 @@
 require "rails_helper"
 
 RSpec.describe FetchStudentsJob do
+  include ActiveJob::TestHelper
+
   let(:etab) { create(:establishment, :with_fim_user) }
 
   before do
@@ -13,5 +15,20 @@ RSpec.describe FetchStudentsJob do
     described_class.perform_now(etab)
 
     expect(StudentApi).to have_received(:fetch_students!).with(etab)
+  end
+
+  context "when the underlying API fails" do
+    before do
+      allow(StudentApi).to receive(:fetch_students!).and_raise(Faraday::UnauthorizedError)
+    end
+
+    it "rescues and retry" do
+      perform_enqueued_jobs do
+        described_class.perform_now(etab)
+      rescue Faraday::UnauthorizedError # rubocop:disable Lint/SuppressedException
+      end
+
+      expect(StudentApi).to have_received(:fetch_students!).exactly(5).times
+    end
   end
 end


### PR DESCRIPTION
We *sometimes* get errors from FREGATA with an invalid signature and a code 401. Catch these and bubble them up to the job so they can be instantly retried (that usually does the... job), until we figure out the underlying cause with the MASA team.

Closes #133