### PR TITLE
controllers: put everyone behind the authenticated controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  before_action :check_maintenance, :set_establishment
+  before_action :authenticate_user!, :check_maintenance, :set_establishment
 
   def after_sign_in_path_for(_resource)
     classes_path

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,7 +2,8 @@
 
 class HomeController < ApplicationController
   layout "maintenance", only: :maintenance
-  before_action :authenticate_user!, only: %i[home welcome]
+
+  skip_before_action :authenticate_user!, only: %i[maintenance index login]
 
   def index
     (redirect_to home_path and return) if user_signed_in?


### PR DESCRIPTION
You can't do much unauthorised but the app will crash on `current_user` rather than redirect.

Closes #134.