### PR TITLE
student: remove the current_schooling_id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,6 +95,7 @@ group :test do
   gem "guard-rspec"
   gem "rails-controller-testing"
   gem "rspec"
+  gem "rspec-collection_matchers"
   gem "rubocop"
   gem "rubocop-rails"
   gem "rubocop-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -417,6 +417,8 @@ GEM
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
       rspec-mocks (~> 3.12.0)
+    rspec-collection_matchers (1.2.1)
+      rspec-expectations (>= 2.99.0.beta1)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
     rspec-expectations (3.12.3)
@@ -589,6 +591,7 @@ DEPENDENCIES
   rails (~> 7)
   rails-controller-testing
   rspec
+  rspec-collection_matchers
   rspec-rails
   rubocop
   rubocop-rails

--- a/Guardfile
+++ b/Guardfile
@@ -30,8 +30,6 @@ guard :rspec, cmd: "bin/rspec" do
   require "guard/rspec/dsl"
   dsl = Guard::RSpec::Dsl.new(self)
 
-  # Feel free to open issues for suggestions and improvements
-
   # RSpec files
   rspec = dsl.rspec
   watch(rspec.spec_helper) { rspec.spec_dir }
@@ -50,8 +48,7 @@ guard :rspec, cmd: "bin/rspec" do
   watch(rails.controllers) do |m|
     [
       rspec.spec.call("routing/#{m[1]}_routing"),
-      rspec.spec.call("controllers/#{m[1]}_controller"),
-      rspec.spec.call("acceptance/#{m[1]}")
+      rspec.spec.call("controllers/#{m[1]}_controller")
     ]
   end
 
@@ -64,14 +61,11 @@ guard :rspec, cmd: "bin/rspec" do
   watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
   watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
 
-  # Turnip features and steps
-  watch(%r{^spec/acceptance/(.+)\.feature$})
-  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
-    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
-  end
-
   # Rake tasks
   watch(%r{^lib/tasks/(.+)\.rake$}) { |m| "spec/lib/tasks/#{m[1]}_spec.rb" }
+
+  # shared examples
+  watch(%r{^app/models/student/mappers/base.rb}) { "spec/models/student/mappers" }
 end
 
 cucumber_options = {

--- a/app/controllers/classes_controller.rb
+++ b/app/controllers/classes_controller.rb
@@ -49,14 +49,19 @@ class ClassesController < ApplicationController
   end
 
   def set_all_classes
-    @classes = @etab.classes.includes(:mef, students: %i[rib pfmps], schoolings: :attributive_decision_attachment)
+    @classes = @etab
+               .classes
+               .current
+               .includes(:mef, :active_pfmps, active_students: :rib)
   end
 
   def set_classe
     @classe = Classe
-              .includes(students: [:rib, { pfmps: :transitions }])
               .where(establishment: @etab)
+              .includes(active_schoolings: [student: :rib])
               .find(params[:id])
+
+    @schoolings = @classe.active_schoolings
   rescue ActiveRecord::RecordNotFound
     redirect_to classes_path, alert: t("errors.classes.not_found") and return
   end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -5,6 +5,8 @@ class HomeController < ApplicationController
 
   skip_before_action :authenticate_user!, only: %i[maintenance index login]
 
+  before_action :show_welcome_screen, only: :home
+
   def index
     (redirect_to home_path and return) if user_signed_in?
 
@@ -12,14 +14,12 @@ class HomeController < ApplicationController
   end
 
   def home
-    redirect_to welcome_path and return unless current_user.welcomed?
-
-    @page_title = t("pages.titles.home.home")
+    infer_page_title
     @inhibit_title = true
 
     current_classes = @etab.classes.current
 
-    @students_count = @etab.schoolings.current.includes(:student).count
+    @students_count = current_classes.joins(:active_students).count
     @attributive_decisions_count = @etab.schoolings.current.joins(:attributive_decision_attachment).count
     @ribs_count = current_classes.joins(students: :rib).count
     @pfmps_counts = pfmp_counts
@@ -53,5 +53,9 @@ class HomeController < ApplicationController
             .merge(@etab.classes.current)
 
     PfmpStateMachine.states.index_with { |state| pfmps.in_state(state).count }
+  end
+
+  def show_welcome_screen
+    redirect_to welcome_path and return unless current_user.welcomed?
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -18,8 +18,9 @@ class HomeController < ApplicationController
     @inhibit_title = true
 
     current_classes = @etab.classes.current
-    @students_count = current_classes.joins(:students).count
-    @attributive_decisions_count = current_classes.with_attributive_decisions.count
+
+    @students_count = @etab.schoolings.current.includes(:student).count
+    @attributive_decisions_count = @etab.schoolings.current.joins(:attributive_decision_attachment).count
     @ribs_count = current_classes.joins(students: :rib).count
     @pfmps_counts = pfmp_counts
   end

--- a/app/helpers/classes_helper.rb
+++ b/app/helpers/classes_helper.rb
@@ -2,8 +2,8 @@
 
 module ClassesHelper
   def avancement_ribs(classe)
-    complete = classe.students.filter_map(&:rib).size
-    all = classe.students.size
+    complete = classe.active_students.filter_map(&:rib).size
+    all = classe.active_students.size
 
     "#{complete}/#{all}"
   end

--- a/app/models/classe.rb
+++ b/app/models/classe.rb
@@ -4,10 +4,28 @@ class Classe < ApplicationRecord
   belongs_to :establishment
   belongs_to :mef
 
-  has_many :schoolings, dependent: nil
+  has_many :schoolings, dependent: :destroy
+
   has_many :students, -> { order "last_name" }, dependent: nil, through: :schoolings
+
   has_many :pfmps, through: :schoolings
-  has_many :attributive_decisions_attachments, through: :schoolings, source: :attributive_decision_attachment
+
+  has_many :attributive_decisions_attachments,
+           through: :schoolings,
+           source: :attributive_decision_attachment
+
+  has_many :active_schoolings,
+           -> { current },
+           dependent: :destroy,
+           class_name: "Schooling",
+           inverse_of: :classe
+
+  has_many :active_students,
+           class_name: "Student",
+           through: :active_schoolings,
+           source: :student
+
+  has_many :active_pfmps, through: :active_students, class_name: "Pfmp", source: :pfmps
 
   validates :label, :start_year, presence: true
   validates :start_year, numericality: { only_integer: true, greater_than_or_equal_to: 2023 }

--- a/app/models/establishment.rb
+++ b/app/models/establishment.rb
@@ -18,7 +18,10 @@ class Establishment < ApplicationRecord
   end
 
   has_many :classes, -> { order "label" }, class_name: "Classe", dependent: :destroy, inverse_of: :establishment
+
   has_many :schoolings, through: :classes
+
+  has_many :students, through: :schoolings
 
   has_one_attached :attributive_decisions_zip
 
@@ -41,7 +44,7 @@ class Establishment < ApplicationRecord
   }.freeze
 
   def current_schoolings
-    classes.current.includes(:schoolings).flat_map(&:schoolings)
+    schoolings.current
   end
 
   def to_s

--- a/app/models/schooling.rb
+++ b/app/models/schooling.rb
@@ -13,15 +13,7 @@ class Schooling < ApplicationRecord
 
   scope :current, -> { where(end_date: nil) }
 
-  after_create :replace_former_schooling
-
-  def replace_former_schooling
-    if student.current_schooling.present? && student.current_schooling != self
-      student.current_schooling.update!(end_date: Time.zone.now)
-    end
-
-    student.update!(current_schooling: self)
-  end
+  validates :student_id, uniqueness: { conditions: -> { current } }
 
   def attributive_decision_filename
     [

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -11,17 +11,21 @@ class Student < ApplicationRecord
   validates :asp_file_reference, uniqueness: true
 
   has_many :schoolings, dependent: :delete_all
+
   has_many :classes, through: :schoolings, source: "classe"
 
   has_many :pfmps, -> { order "pfmps.start_date" }, through: :schoolings
 
-  belongs_to :current_schooling, optional: true, class_name: "Schooling", dependent: :destroy
+  has_one :current_schooling, -> { current }, class_name: "Schooling", dependent: :destroy, inverse_of: :student
+
   has_one :classe, through: :current_schooling
 
   has_one :establishment, through: :classe
+
   has_many :payments, through: :pfmps
 
   has_many :ribs, dependent: :destroy
+
   has_one :rib, -> { where(archived_at: nil) }, dependent: :destroy, inverse_of: :student
 
   before_validation :check_asp_file_reference
@@ -47,10 +51,7 @@ class Student < ApplicationRecord
   end
 
   def close_current_schooling!
-    return if current_schooling.nil?
-
-    current_schooling.update!(end_date: Time.zone.today)
-    update!(current_schooling: nil)
+    current_schooling&.update!(end_date: Time.zone.today)
   end
 
   def address

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -50,8 +50,8 @@ class Student < ApplicationRecord
     current_schooling.mef.wage.yearly_cap - used_allowance
   end
 
-  def close_current_schooling!
-    current_schooling&.update!(end_date: Time.zone.today)
+  def close_current_schooling!(date = Time.zone.today)
+    current_schooling&.update!(end_date: date)
   end
 
   def address

--- a/app/models/student/mappers/base.rb
+++ b/app/models/student/mappers/base.rb
@@ -64,7 +64,7 @@ class Student
 
       def check_schoolings!
         payload
-          .filter { |entry| student_is_gone?(entry) }
+          .filter { |entry| student_has_left_class?(entry) }
           .filter_map { |entry| Student.find_by(ine: map_student_attributes(entry)[:ine]) }
           .each(&:close_current_schooling!)
       end
@@ -77,6 +77,10 @@ class Student
       # [1]: https://bv.ac-nantes.fr/affelnet-lycee-resultatsetab/aide/104-ecr-formations.htm
       def chop_mef_code(code)
         code.chop
+      end
+
+      def student_has_left_class?(entry)
+        student_has_changed_class?(entry) || student_has_left_establishment?(entry)
       end
 
       def inspect

--- a/app/models/student/mappers/base.rb
+++ b/app/models/student/mappers/base.rb
@@ -76,9 +76,13 @@ class Student
 
       def check_schoolings!
         payload
-          .filter { |entry| student_has_left_class?(entry) }
-          .filter_map { |entry| Student.find_by(ine: map_student_attributes(entry)[:ine]) }
-          .each(&:close_current_schooling!)
+          .filter { |entry| student_has_left_class?(entry) && find_existing_student(entry) }
+          .map    { |entry| [entry, find_existing_student(entry)] }
+          .each   { |entry, student| student.close_current_schooling!(left_classe_at(entry)) }
+      end
+
+      def find_existing_student(entry)
+        Student.find_by(ine: map_student_attributes(entry)[:ine])
       end
 
       # the MEF codes from SYGNE and FREGATA all arrive with an extra

--- a/app/models/student/mappers/base.rb
+++ b/app/models/student/mappers/base.rb
@@ -18,7 +18,10 @@ class Student
           .transform_values! { |student_attrs| map_students!(student_attrs) }
           .each do |classe, students|
           students.each do |student|
-            Schooling.find_or_create_by!(classe: classe, student: student)
+            if !Schooling.find_by(classe: classe, student: student)
+              student.close_current_schooling!
+              Schooling.create(classe: classe, student: student)
+            end
           end
         end
 

--- a/app/models/student/mappers/fregata.rb
+++ b/app/models/student/mappers/fregata.rb
@@ -47,14 +47,18 @@ class Student
         student_attrs
       end
 
-      def student_is_gone?(entry)
-        left_establishment?(entry)
+      def student_has_changed_class?(entry)
+        timestamp_past?(entry["dateSortieFormation"])
       end
 
-      def left_establishment?(entry)
-        left_at = entry["dateSortieEtablissement"]
+      def student_has_left_establishment?(entry)
+        timestamp_past?(entry["dateSortieEtablissement"])
+      end
 
-        Date.parse(left_at).past? if left_at.present?
+      private
+
+      def timestamp_past?(value)
+        value.present? && Date.parse(value).past?
       end
     end
   end

--- a/app/models/student/mappers/fregata.rb
+++ b/app/models/student/mappers/fregata.rb
@@ -48,11 +48,15 @@ class Student
       end
 
       def student_has_changed_class?(entry)
-        timestamp_past?(entry["dateSortieFormation"])
+        timestamp_past?(left_classe_at(entry))
       end
 
       def student_has_left_establishment?(entry)
         timestamp_past?(entry["dateSortieEtablissement"])
+      end
+
+      def left_classe_at(entry)
+        entry["dateSortieFormation"] || entry["dateSortieEtablissement"]
       end
 
       private

--- a/app/models/student/mappers/sygne.rb
+++ b/app/models/student/mappers/sygne.rb
@@ -40,12 +40,12 @@ class Student
         end
       end
 
-      def student_is_gone?(entry)
-        no_classe_for_entry?(entry)
+      def student_has_changed_class?(entry)
+        entry["classe"].blank?
       end
 
-      def no_classe_for_entry?(entry)
-        entry["classe"].blank?
+      def student_has_left_establishment?(_entry)
+        false
       end
     end
   end

--- a/app/models/student/mappers/sygne.rb
+++ b/app/models/student/mappers/sygne.rb
@@ -47,6 +47,10 @@ class Student
       def student_has_left_establishment?(_entry)
         false
       end
+
+      def left_classe_at(_entry)
+        nil # we don't know
+      end
     end
   end
 end

--- a/app/views/classes/index.html.haml
+++ b/app/views/classes/index.html.haml
@@ -16,6 +16,6 @@
           %tr
             %td
               = dsfr_link_to classe.to_long_s, classe, title: t("links.classes.show", label: classe.to_long_s)
-            %td= classe.students.size
-            %td= classe.students.map(&:pfmps).flatten.size
+            %td= classe.active_students.size
+            %td= classe.active_pfmps.size
             %td= avancement_ribs(classe)

--- a/app/views/classes/show.html.haml
+++ b/app/views/classes/show.html.haml
@@ -5,14 +5,15 @@
 
 .fr-table.fr-table--no-caption
   %table
-    %caption Liste des élèves (#{@classe.students.count})
+    %caption Liste des élèves (#{@schoolings.count})
     %thead
       %th{scope: "col"} Élève
       %th{scope: "col"} PFMPs
       %th{scope: "col"} RIB présent
 
     %tbody
-      - @classe.students.each do |student|
+      - @schoolings.each do |schooling|
+        - student = schooling.student
         %tr
           %td
             = dsfr_link_to student.index_name, class_student_path(@classe, student), title: t("links.students.show", name: student)

--- a/db/migrate/20231112172554_remove_current_schooling_id_from_students.rb
+++ b/db/migrate/20231112172554_remove_current_schooling_id_from_students.rb
@@ -1,9 +1,20 @@
 # frozen_string_literal: true
 
 class RemoveCurrentSchoolingIdFromStudents < ActiveRecord::Migration[7.1]
-  def change
+  def up
     remove_reference :students, :current_schooling, foreign_key: { column: "current_schooling_id" }
 
-    add_index :schoolings, %i[student_id end_date], unique: true, where: "end_date is NULL"
+    execute <<~SQL.squish
+      CREATE UNIQUE INDEX one_active_schooling_per_student
+      ON schoolings(student_id, end_date)
+      NULLS NOT DISTINCT
+      WHERE (end_date IS NULL)
+    SQL
+  end
+
+  def down
+    add_reference :students, :current_schooling, foreign_key: { to_table: :schoolings }
+
+    execute "DROP INDEX one_active_schooling_per_student"
   end
 end

--- a/db/migrate/20231112172554_remove_current_schooling_id_from_students.rb
+++ b/db/migrate/20231112172554_remove_current_schooling_id_from_students.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class RemoveCurrentSchoolingIdFromStudents < ActiveRecord::Migration[7.1]
+  def change
+    remove_reference :students, :current_schooling, foreign_key: { column: "current_schooling_id" }
+
+    add_index :schoolings, %i[student_id end_date], unique: true, where: "end_date is NULL"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -169,7 +169,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_12_172554) do
     t.datetime "updated_at", null: false
     t.integer "attributive_decision_version", default: 0
     t.index ["classe_id"], name: "index_schoolings_on_classe_id"
-    t.index ["student_id", "end_date"], name: "index_schoolings_on_student_id_and_end_date", unique: true, where: "(end_date IS NULL)"
+    t.index ["student_id", "end_date"], name: "one_active_schooling_per_student", unique: true, where: "(end_date IS NULL)", nulls_not_distinct: true
     t.index ["student_id"], name: "index_schoolings_on_student_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_08_161014) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_12_172554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -169,6 +169,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_08_161014) do
     t.datetime "updated_at", null: false
     t.integer "attributive_decision_version", default: 0
     t.index ["classe_id"], name: "index_schoolings_on_classe_id"
+    t.index ["student_id", "end_date"], name: "index_schoolings_on_student_id_and_end_date", unique: true, where: "(end_date IS NULL)"
     t.index ["student_id"], name: "index_schoolings_on_student_id"
   end
 
@@ -179,7 +180,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_08_161014) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.date "birthdate", null: false
-    t.bigint "current_schooling_id"
     t.string "asp_file_reference", null: false
     t.string "address_line1"
     t.string "address_line2"
@@ -188,7 +188,6 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_08_161014) do
     t.string "city"
     t.string "country_code"
     t.index ["asp_file_reference"], name: "index_students_on_asp_file_reference", unique: true
-    t.index ["current_schooling_id"], name: "index_students_on_current_schooling_id"
     t.index ["ine"], name: "index_students_on_ine", unique: true
   end
 
@@ -238,6 +237,5 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_08_161014) do
   add_foreign_key "ribs", "students"
   add_foreign_key "schoolings", "classes", column: "classe_id"
   add_foreign_key "schoolings", "students"
-  add_foreign_key "students", "schoolings", column: "current_schooling_id"
   add_foreign_key "users", "establishments"
 end

--- a/features/anciens_eleves.feature
+++ b/features/anciens_eleves.feature
@@ -1,6 +1,6 @@
 # language: fr
 
-@wip
+
 Fonctionnalité: Les anciens élèves ne sont pas inclus dans l'interface
   Contexte:
     Sachant que l'API SYGNE renvoie 10 élèves en "1MELEC" dont l'INE "test" pour l'établissement "DINUM"

--- a/features/anciens_eleves.feature
+++ b/features/anciens_eleves.feature
@@ -1,0 +1,25 @@
+# language: fr
+
+@wip
+Fonctionnalité: Les anciens élèves ne sont pas inclus dans l'interface
+  Contexte:
+    Sachant que l'API SYGNE renvoie 10 élèves en "1MELEC" dont l'INE "test" pour l'établissement "DINUM"
+    Et que je suis un personnel MENJ directeur de l'établissement "DINUM"
+    Et que je me connecte en tant que personnel MENJ
+    Et que je passe l'écran d'accueil
+    Et que toutes les tâches de fond sont terminées
+    Sachant que l'élève de SYGNE avec l'INE "test" a quitté l'établissement "DINUM"
+
+  Scénario: Les anciens élèves ne sont pas affichés dans le compteur des décisions d'attribution
+    Quand je rafraîchis la page
+    Alors le panneau "Décisions d'attribution" contient "0 / 9"
+
+  Scénario: Les anciens élèves ne sont pas affichés dans le compteur des saisies banciares
+    Quand je rafraîchis la page
+    Alors le panneau "Coordonnées bancaires" contient "0 / 9"
+
+  Scénario: Les anciens élèves ne sont pas affichés dans les listings de classe
+    Quand je consulte la liste des classes
+    Alors le tableau "Liste des classes" contient
+      | Classe | Effectif | Nombre de PFMPs | Coordonnées bancaires |
+      | 1MELEC |        9 |               0 | 0/9                   |

--- a/features/consultation_des_listes.feature
+++ b/features/consultation_des_listes.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Le personnel de direction consulte les listes
     Et que je me connecte en tant que personnel MENJ
     Et que je passe l'écran d'accueil
     Et que je clique sur "Élèves"
-    Et qu'il y a une élève "Marie Curie" au sein de la classe "2NDEB" pour une formation "Développement"
+    Et qu'il y a une élève "Marie Curie" avec l'UAI "test" au sein de la classe "2NDEB" pour une formation "Développement"
     Et que je rafraîchis la page
 
   Scénario: Le personnel de direction consulte le profil d'un élève
@@ -19,3 +19,8 @@ Fonctionnalité: Le personnel de direction consulte les listes
     Quand je renseigne les coordonnées bancaires de l'élève "Marie Curie" de la classe "2NDEB"
     Et que je consulte la liste des classes
     Alors la page contient "1/"
+
+  Scénario: Les élèves qui ne sont plus dans la classe ne sont pas affichés
+    Quand l'élève avec l'INE "test" a quitté l'établissement "DINUM"
+    Et que je clique sur "Voir la classe" dans la rangée "2NDEB"
+    Alors la page ne contient pas "Curie Marie"

--- a/features/consultation_des_listes.feature
+++ b/features/consultation_des_listes.feature
@@ -19,8 +19,3 @@ Fonctionnalité: Le personnel de direction consulte les listes
     Quand je renseigne les coordonnées bancaires de l'élève "Marie Curie" de la classe "2NDEB"
     Et que je consulte la liste des classes
     Alors la page contient "1/"
-
-  Scénario: Les élèves qui ne sont plus dans la classe ne sont pas affichés
-    Quand l'élève avec l'INE "test" a quitté l'établissement "DINUM"
-    Et que je clique sur "Voir la classe" dans la rangée "2NDEB"
-    Alors la page ne contient pas "Curie Marie"

--- a/features/consultation_des_listes.feature
+++ b/features/consultation_des_listes.feature
@@ -6,7 +6,7 @@ Fonctionnalité: Le personnel de direction consulte les listes
     Et que je me connecte en tant que personnel MENJ
     Et que je passe l'écran d'accueil
     Et que je clique sur "Élèves"
-    Et qu'il y a une élève "Marie Curie" avec l'UAI "test" au sein de la classe "2NDEB" pour une formation "Développement"
+    Et qu'il y a une élève "Marie Curie" au sein de la classe "2NDEB" pour une formation "Développement"
     Et que je rafraîchis la page
 
   Scénario: Le personnel de direction consulte le profil d'un élève

--- a/features/décisions_d_attributions.feature
+++ b/features/décisions_d_attributions.feature
@@ -2,13 +2,16 @@
 
 Fonctionnalité: Le personnel de direction peut éditer les décisions d'attribution
   Contexte:
-    Sachant que l'API SYGNE renvoie une liste d'élèves pour l'établissement "DINUM"
+    Sachant que l'API SYGNE renvoie 10 élèves en "1MELEC" dont l'INE "test" pour l'établissement "DINUM"
     Et que l'API SYGNE peut fournir les informations complètes des étudiants
     Et que je suis un personnel MENJ directeur de l'établissement "DINUM"
     Et que je me connecte en tant que personnel MENJ
-    Et qu'il y a une élève "Marie Curie" au sein de la classe "2NDEB" pour une formation "Développement"
     Et que je passe l'écran d'accueil
-    Et que le panneau "Décisions d'attribution" contient "0 / 1"
+    Quand toutes les tâches de fond sont terminées
+
+  Scénario: Le personnel de direction peut voir le nombre de décisions à générer
+    Quand je rafraîchis la page
+    Alors le panneau "Décisions d'attribution" contient "0 / 10"
 
   Scénario: Le personnel de direction peut lancer l'édition des décisions d'attribution
     Quand je clique sur "Éditer les décisions d'attribution"
@@ -16,4 +19,4 @@ Fonctionnalité: Le personnel de direction peut éditer les décisions d'attribu
     Quand toutes les tâches de fond sont terminées
     Et que je rafraîchis la page
     Alors la page contient "Télécharger l'ensemble des décisions d'attribution"
-    Alors le panneau "Décisions d'attribution" contient "1 / 1"
+    Et le panneau "Décisions d'attribution" contient "10 / 10"

--- a/features/recuperation_eleves.feature
+++ b/features/recuperation_eleves.feature
@@ -2,7 +2,7 @@
 
 Fonctionnalité: Le personnel de direction récupère correctement les élèves
   Scénario: Le personnel de direction MENJ récupère ses élèves
-    Sachant que l'API SYGNE renvoie une liste d'élèves pour l'établissement "DINUM"
+    Sachant que l'API SYGNE renvoie 10 élèves en "1MELEC" dont l'INE "test" pour l'établissement "DINUM"
     Et que je suis un personnel MENJ directeur de l'établissement "DINUM"
     Et que je me connecte en tant que personnel MENJ
     Et que je passe l'écran d'accueil

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -38,8 +38,3 @@ Sachantque("l'API SYGNE renvoie un élève avec l'INE {string} qui a quitté l'�
   WebmockHelpers.mock_sygne_token_with
   WebmockHelpers.mock_sygne_students_endpoint_with(uai, payload_without_student)
 end
-
-Sachantque("l'API SYGNE renvoie une liste d'élèves vide") do
-  WebmockHelpers.mock_sygne_token_with
-  WebmockHelpers.mock_sygne_students_with!([])
-end

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require Rails.root.join "spec/support/webmock_helpers.rb"
-
 Sachantque("l'API FREGATA renvoie une liste d'élèves pour l'établissement {string}") do |uai|
   WebmockHelpers.mock_fregata_students_with(uai, FactoryBot.build_list(:fregata_student, 10))
 end
@@ -15,6 +13,18 @@ Sachantque("l'API SYGNE peut fournir les informations complètes des étudiants"
   WebmockHelpers.mock_sygne_student_endpoint_with("", FactoryBot.build(:sygne_student_info).to_json)
 end
 
+Sachantque("les élèves de l'établissement {string} sont rafraîchis") do |uai|
+  FetchStudentsJob.new(Establishment.find_by(uai: uai)).perform_now
+end
+
+Sachantque("l'API SYGNE renvoie un élève avec l'INE {string} qui a quitté l'établissement {string}") do |ine, uai|
+  gone_payload = FactoryBot.build_list(:sygne_student, 1, :gone, ine: ine).to_json
+
+  WebmockHelpers.mock_sygne_token_with
+  WebmockHelpers.mock_sygne_students_endpoint_with(uai, gone_payload)
+end
+
 Sachantque("l'API SYGNE renvoie une liste d'élèves vide") do
+  WebmockHelpers.mock_sygne_token_with
   WebmockHelpers.mock_sygne_students_with!([])
 end

--- a/features/step_definitions/job_steps.rb
+++ b/features/step_definitions/job_steps.rb
@@ -3,3 +3,7 @@
 Quand("toutes les tâches de fond sont terminées") do
   perform_enqueued_jobs
 end
+
+Quand("la liste des élèves de l'établissement {string} est rafraîchie") do |uai|
+  FetchStudentsJob.perform_later(Establishment.find_by(uai: uai))
+end

--- a/features/step_definitions/perdir_steps.rb
+++ b/features/step_definitions/perdir_steps.rb
@@ -14,6 +14,19 @@ Et("mon établissement a été hydraté") do
 end
 
 Sachantque(
+  "il y a un(e) élève {string} avec l'UAI {string} au sein de la classe {string} pour une formation {string}"
+) do |name, ine, classe, mef|
+  @etab ||= User.last.establishment
+
+  first, last = name.split # not great
+
+  @mef = FactoryBot.create(:mef, label: mef)
+  @classe = FactoryBot.create(:classe, establishment: @etab, label: classe, mef: @mef)
+  @student = FactoryBot.create(:student, first_name: first, last_name: last, ine: ine)
+  @student.schoolings.create!(classe: @classe)
+end
+
+Sachantque(
   "il y a un(e) élève {string} au sein de la classe {string} pour une formation {string}"
 ) do |name, classe, mef|
   @etab ||= User.last.establishment

--- a/features/step_definitions/perdir_steps.rb
+++ b/features/step_definitions/perdir_steps.rb
@@ -14,19 +14,6 @@ Et("mon établissement a été hydraté") do
 end
 
 Sachantque(
-  "il y a un(e) élève {string} avec l'UAI {string} au sein de la classe {string} pour une formation {string}"
-) do |name, ine, classe, mef|
-  @etab ||= User.last.establishment
-
-  first, last = name.split # not great
-
-  @mef = FactoryBot.create(:mef, label: mef)
-  @classe = FactoryBot.create(:classe, establishment: @etab, label: classe, mef: @mef)
-  @student = FactoryBot.create(:student, first_name: first, last_name: last, ine: ine)
-  @student.schoolings.create!(classe: @classe)
-end
-
-Sachantque(
   "il y a un(e) élève {string} au sein de la classe {string} pour une formation {string}"
 ) do |name, classe, mef|
   @etab ||= User.last.establishment

--- a/features/step_definitions/student_steps.rb
+++ b/features/step_definitions/student_steps.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require Rails.root.join "spec/support/webmock_helpers.rb"
+
+Quand("l'élève avec l'INE {string} a quitté l'établissement {string}") do |ine, uai|
+  steps %(
+    Sachant que l'API SYGNE renvoie un élève avec l'INE "#{ine}" qui a quitté l'établissement "#{uai}"
+    Et que la liste des élèves de l'établissement "#{uai}" est rafraîchie
+    Et que toutes les tâches de fond sont terminées
+    )
+end

--- a/features/step_definitions/student_steps.rb
+++ b/features/step_definitions/student_steps.rb
@@ -2,7 +2,7 @@
 
 require Rails.root.join "spec/support/webmock_helpers.rb"
 
-Quand("l'élève avec l'INE {string} a quitté l'établissement {string}") do |ine, uai|
+Quand("l'élève de SYGNE avec l'INE {string} a quitté l'établissement {string}") do |ine, uai|
   steps %(
     Sachant que l'API SYGNE renvoie un élève avec l'INE "#{ine}" qui a quitté l'établissement "#{uai}"
     Et que la liste des élèves de l'établissement "#{uai}" est rafraîchie

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -24,6 +24,10 @@ Alors("la page contient {string} dans la rangée {string} du tableau {string}") 
   expect(page).to have_table(caption, with_rows: [row, content])
 end
 
+Alors("le tableau {string} contient") do |caption, table|
+  expect(page).to have_table(caption, with_rows: table.rows)
+end
+
 Alors("le titre de la page contient {string}") do |text|
   expect(page.title.gsub("  ", " ")).to include text
 end

--- a/spec/models/classe_spec.rb
+++ b/spec/models/classe_spec.rb
@@ -52,6 +52,19 @@ RSpec.describe Classe do
     end
   end
 
+  describe "#active_students" do
+    subject(:active_students) { classe.active_students }
+
+    let(:classe) { create(:classe, :with_students, students_count: 5) }
+    let(:old_student) { classe.students.last }
+
+    before do
+      old_student.close_current_schooling!
+    end
+
+    it { is_expected.not_to include old_student }
+  end
+
   describe ".with_attributive_decisions" do
     let(:classe_with_no_ad) { create(:classe, :with_students) }
     let(:classe_with_ad) { create(:classe, :with_students) }

--- a/spec/models/pfmp_spec.rb
+++ b/spec/models/pfmp_spec.rb
@@ -4,12 +4,12 @@ require "rails_helper"
 
 RSpec.describe Pfmp do
   subject(:pfmp) do
-    create(:pfmp, student: student).tap { |p| p.payments.destroy_all }
+    create(:pfmp, schooling: schooling).tap { |p| p.payments.destroy_all }
   end
 
   let(:mef) { create(:mef) }
   let(:classe) { create(:classe, mef: mef) }
-  let(:student) { create(:schooling).student }
+  let(:schooling) { create(:schooling) }
 
   describe "associations" do
     it { is_expected.to belong_to(:schooling) }
@@ -121,7 +121,7 @@ RSpec.describe Pfmp do
 
   describe "setup_payment!" do
     subject(:pfmp) do
-      create(:pfmp, :completed, student: student).tap { |p| p.payments.destroy_all }
+      create(:pfmp, :completed, schooling: schooling).tap { |p| p.payments.destroy_all }
     end
 
     context "when there are no payments" do
@@ -132,7 +132,7 @@ RSpec.describe Pfmp do
 
     context "when the student has already reached the yearly cap" do
       before do
-        create(:pfmp, :validated, student: pfmp.student, day_count: 200).tap do |p|
+        create(:pfmp, :validated, schooling: pfmp.schooling, day_count: 200).tap do |p|
           p.latest_payment.transition_to!(:processing)
           p.latest_payment.transition_to!(:success)
         end

--- a/spec/models/student/mappers/fregata_spec.rb
+++ b/spec/models/student/mappers/fregata_spec.rb
@@ -25,7 +25,7 @@ describe Student::Mappers::Fregata do
     let(:nil_ine_payload) { normal_payload.push(build(:fregata_student, :no_ine)) }
     let(:irrelevant_mefs_payload) { build_list(:fregata_student, 10, :irrelevant) }
     let(:gone_student_payload) { build_list(:fregata_student, 1, :gone, ine: student_ine) }
-    let(:changed_class_student_payload) { build_list(:fregata_student, 1, ine: student_ine, classe_label: "NEW") }
+    let(:changed_class_student_payload) { build_list(:fregata_student, 1, :changed_class, ine: student_ine) }
   end
 
   it "also grabs the address" do

--- a/spec/models/student/mappers/fregata_spec.rb
+++ b/spec/models/student/mappers/fregata_spec.rb
@@ -9,28 +9,43 @@ describe Student::Mappers::Fregata do
   subject(:mapper) { described_class }
 
   let(:establishment) { create(:establishment, :with_masa_user) }
-  let(:data) { normal_payload }
-  let(:normal_payload) { build_list(:fregata_student, 2) }
-  let(:student_ine) { normal_payload.first["apprenant"]["ine"] }
+  let(:normal_payload) { build_list(:fregata_student, 2, classe_label: "1AGRO") }
+  let(:last_ine) { normal_payload.last["apprenant"]["ine"] }
 
   it_behaves_like "a student mapper" do
-    let(:establishment) { create(:establishment, :with_masa_user) }
-    let(:data) { normal_payload }
-
     # the following lines to test with some massive staging payloads
     # let!(:fixture) { Rails.root.join("mock/data/fregata-students.json").read }
-    # let(:data) { JSON.parse(fixture) }
+    # let(:normal_payload) { JSON.parse(fixture) }
 
-    let(:empty_payload) { build_list(:fregata_student, 0) }
-    let(:nil_ine_payload) { normal_payload.push(build(:fregata_student, :no_ine)) }
     let(:irrelevant_mefs_payload) { build_list(:fregata_student, 10, :irrelevant) }
-    let(:gone_student_payload) { build_list(:fregata_student, 1, :gone, ine: student_ine) }
-    let(:changed_class_student_payload) { build_list(:fregata_student, 1, :changed_class, ine: student_ine) }
+    let(:nil_ine_payload) { normal_payload.push(build(:fregata_student, :no_ine)) }
+    let(:last_student_has_changed_class_payload) do
+      normal_payload.dup << build(:fregata_student, :changed_class, ine: last_ine)
+    end
+
+    let(:last_student_has_left_establishment_payload) do
+      normal_payload.dup << build(:fregata_student, :left_establishment, ine: last_ine)
+    end
   end
 
   it "also grabs the address" do
-    mapper.new(data, establishment).parse!
+    mapper.new(normal_payload, establishment).parse!
 
-    expect(Student.find_by(ine: student_ine)).not_to be_missing_address
+    expect(Student.all.map(&:missing_address?).uniq).to contain_exactly false
+  end
+
+  context "when there are multiple entries for the same student" do
+    let(:data) do
+      [
+        build(:fregata_student, ine: last_ine),
+        build(:fregata_student, :changed_class, ine: last_ine)
+      ]
+    end
+
+    it "parses them correctly" do
+      mapper.new(data, establishment).parse!
+
+      expect(Student.find_by(ine: last_ine).schoolings).to have(2).schoolings
+    end
   end
 end

--- a/spec/models/student/mappers/sygne_spec.rb
+++ b/spec/models/student/mappers/sygne_spec.rb
@@ -6,17 +6,19 @@ require "./mock/factories/api_student"
 require "./spec/support/shared/student_mapper"
 
 describe Student::Mappers::Sygne do
-  subject(:mapper) { described_class }
-
   it_behaves_like "a student mapper" do
     let(:establishment) { create(:establishment, :with_fim_user) }
-    let(:data) { normal_payload }
-    let(:normal_payload) { build_list(:sygne_student, 10) }
-    let(:empty_payload) { build_list(:sygne_student, 0) }
-    let(:student_ine) { normal_payload.first["ine"] }
+    let(:normal_payload) { build_list(:sygne_student, 10, classe: "1MELEC") }
     let(:irrelevant_mefs_payload) { build_list(:sygne_student, 10, codeMef: "-1") }
     let(:nil_ine_payload) { normal_payload.push(build(:sygne_student, :no_ine)) }
-    let(:gone_student_payload) { build_list(:sygne_student, 1, :gone, ine: student_ine) }
-    let(:changed_class_student_payload) { build_list(:sygne_student, 1, ine: student_ine, classe: "NEW") }
+    let(:last_ine) { normal_payload.last["ine"] }
+    let(:last_student_has_changed_class_payload) do
+      normal_payload.dup.tap do |students|
+        students.last["classe"] = "some new class"
+      end
+    end
+
+    # with SYGNE, a known student not present in the payload means they're gone
+    let(:last_student_has_left_establishment_payload) { normal_payload.dup.tap(&:pop) }
   end
 end

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -43,15 +43,33 @@ RSpec.describe Student do
     # rubocop:enable RSpec/SubjectStub
   end
 
+  describe "current_schooling" do
+    subject(:current_schooling) { student.reload.current_schooling }
+
+    let!(:schooling) { create(:schooling, student: student) }
+
+    it { is_expected.to eq schooling }
+
+    context "when it is closed" do
+      before { schooling.update!(end_date: Date.yesterday) }
+
+      it { is_expected.to be_nil }
+    end
+
+    it "is always unique" do
+      expect { create(:schooling, student: student) }.to raise_error ActiveRecord::RecordInvalid
+    end
+  end
+
   describe "close_current_schooling!" do
-    let(:schooling) { create(:schooling, student: student) }
+    let!(:schooling) { create(:schooling, student: student) }
 
     it "removes the current schooling" do
-      expect { student.close_current_schooling! }.to change(student, :current_schooling).from(schooling).to(nil)
+      expect { student.close_current_schooling! }.to change { student.reload.current_schooling }.from(schooling).to(nil)
     end
 
     it "sets the end date" do
-      expect { student.close_current_schooling! }.to change(schooling, :end_date)
+      expect { student.reload.close_current_schooling! }.to(change { schooling.reload.end_date })
     end
 
     context "when there is no current schooling" do

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -72,6 +72,13 @@ RSpec.describe Student do
       expect { student.reload.close_current_schooling! }.to(change { schooling.reload.end_date })
     end
 
+    it "can use a specific end date" do
+      datetime = 5.days.ago
+
+      expect { student.close_current_schooling!(datetime) }
+        .to(change { schooling.reload.end_date }.to(datetime.to_date))
+    end
+
     context "when there is no current schooling" do
       before { student.close_current_schooling! }
 

--- a/spec/requests/pfmps_controller_spec.rb
+++ b/spec/requests/pfmps_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe "PfmpsController" do
   let(:schooling) { create(:schooling) }
   let(:student) { schooling.student }
   let(:user) { create(:user, :director, establishment: student.classe.establishment) }
-  let(:pfmp) { create(:pfmp, student: student) }
+  let(:pfmp) { create(:pfmp, schooling: schooling) }
 
   before do
     sign_in(user)
@@ -30,7 +30,7 @@ RSpec.describe "PfmpsController" do
   end
 
   describe "POST /validate" do
-    let(:pfmp) { create(:pfmp, :completed, student: student) }
+    let(:pfmp) { create(:pfmp, :completed, schooling: schooling) }
 
     context "when validating as a director" do
       it "returns 200" do

--- a/spec/support/shared/student_mapper.rb
+++ b/spec/support/shared/student_mapper.rb
@@ -15,6 +15,12 @@ RSpec.shared_examples "a student mapper" do
     expect { mapper.parse! }.not_to change(Student, :count)
   end
 
+  it "parses schooling idempotently" do
+    mapper.parse!
+
+    expect { mapper.parse! }.not_to change(Schooling.current, :count)
+  end
+
   it "doesn't crash on students without an INE" do
     expect { described_class.new(nil_ine_payload, establishment).parse! }.not_to raise_error
   end

--- a/spec/support/shared/student_mapper.rb
+++ b/spec/support/shared/student_mapper.rb
@@ -2,118 +2,79 @@
 
 require "rails_helper"
 
-RSpec.shared_examples "a student mapper" do
-  subject(:mapper) { described_class.new(data, establishment) }
-
-  it "upserts the students" do
-    expect { mapper.parse! }.to change(Student, :count).by_at_most(data.length)
+RSpec.shared_examples "closes the current schooling" do
+  it "closes the student's previous schooling" do
+    expect { next_mapper.parse! }.to(change { student.reload.current_schooling })
   end
 
-  it "doesn't duplicate students" do
-    mapper.parse!
-
-    expect { mapper.parse! }.not_to change(Student, :count)
-  end
-
-  it "parses schooling idempotently" do
-    mapper.parse!
-
-    expect { mapper.parse! }.not_to change(Schooling.current, :count)
-  end
-
-  it "doesn't crash on students without an INE" do
-    expect { described_class.new(nil_ine_payload, establishment).parse! }.not_to raise_error
-  end
-
-  it "doesn't crash on an empty payload" do
-    expect { described_class.new(empty_payload, establishment).parse! }.not_to raise_error
-  end
-
-  it "upserts the classes" do
-    expect { mapper.parse! }.to change(Classe, :count)
-  end
-
-  it "creates schoolings" do
-    expect { mapper.parse! }.to change(Schooling, :count).by_at_most(data.length)
-  end
-
-  it "marks the schoolings as current" do
-    mapper.parse!
-
-    Student.find_each do |student|
-      expect(student.current_schooling).not_to be_nil
-    end
-  end
-
-  describe "student attributes parsing" do
-    before { mapper.parse! }
-
-    %i[first_name last_name ine birthdate].each do |attr|
-      it "parses the '#{attr}' attribute" do
-        expect(Student.last[attr]).not_to be_nil
-      end
-    end
-  end
-
-  describe "when some students have already left on the first parse" do
-    subject(:mapper) { described_class.new(gone_student_payload, establishment) }
-
-    it "does not crash" do
-      expect { mapper.parse! }.not_to raise_error
-    end
-  end
-
-  describe "when there are irrelevant MEFS" do
-    let(:data) { irrelevant_mefs_payload }
-
-    it "skips them" do
-      expect { mapper.parse! }.not_to change(Student, :count)
-    end
-  end
-
-  describe "subsequent updates" do
-    let(:student) { Student.find_by(ine: student_ine) }
-
-    before { mapper.parse! }
-
-    describe "when a student has already moved" do
-      it "can handle parsing it again" do
-        expect do
-          described_class.new(gone_student_payload, establishment).parse!
-          described_class.new(gone_student_payload, establishment).parse!
-        end.not_to raise_error
-      end
-    end
-
-    describe "when a student is not in a class anymore" do
-      let(:new_mapper) { described_class.new(gone_student_payload, establishment) }
-
-      include_examples "student has moved"
-    end
-
-    describe "when a student has changed class" do
-      let(:new_mapper) { described_class.new(changed_class_student_payload, establishment) }
-
-      include_examples "student has moved"
-    end
-
-    describe "when a student has changed establishment" do
-      let(:new_establishment) { create(:establishment) }
-      let(:new_mapper) { described_class.new(changed_class_student_payload, new_establishment) }
-
-      include_examples "student has moved"
-    end
+  it "sets the end date on the previous schooling" do
+    expect { next_mapper.parse! }.to(change { student.schoolings.first.end_date })
   end
 end
 
-RSpec.shared_examples "student has moved" do
-  it "removes the current schooling on that student" do
-    expect { new_mapper.parse! }.to(change { student.reload.current_schooling })
+RSpec.shared_examples "a student mapper" do
+  subject(:mapper) { described_class.new(data, establishment) }
+
+  context "with a normal payload" do
+    let(:data) { normal_payload }
+
+    it "upserts the students" do
+      expect { 2.times { mapper.parse! } }.to change(Student, :count).by(data.length)
+    end
+
+    it "upserts the schoolings" do
+      expect { 2.times { mapper.parse! } }.to change(Schooling.current, :count).by(data.length)
+    end
+
+    it "upserts the classes" do
+      expect { 2.times { mapper.parse! } }.to change(Classe, :count).by_at_most(data.length)
+    end
   end
 
-  it "sets the end date on the old schooling" do
-    schooling = student.current_schooling
+  context "with a payload that contains students without INEs" do
+    let(:data) { nil_ine_payload }
 
-    expect { new_mapper.parse! }.to change { schooling.reload.end_date }.from(nil).to(Time.zone.today)
+    it "doesn't crash on students without an INE" do
+      expect { described_class.new(nil_ine_payload, establishment).parse! }.not_to raise_error
+    end
+  end
+
+  context "when the payload is empty" do
+    let(:data) { [] }
+
+    it "doesn't crash" do
+      expect { mapper.parse! }.not_to raise_error
+    end
+
+    context "when there are students in the establishments" do
+      before { described_class.new(normal_payload, establishment).parse! }
+
+      it "doesn't aggressively clean previous schoolings" do
+        expect { mapper.parse! }.not_to change(Schooling.current, :count)
+      end
+    end
+  end
+
+  describe "updates" do
+    subject(:next_mapper) { described_class.new(next_data, establishment) }
+
+    let(:data) { normal_payload }
+    let(:next_data) { update_payload }
+
+    before { mapper.parse! }
+
+    context "when a student has changed class" do
+      let(:next_data) { last_student_has_changed_class_payload }
+      let(:student) { Student.find_by(ine: last_ine) }
+
+      include_examples "closes the current schooling"
+    end
+
+    context "when a student has left the establishment" do
+      let(:next_data) { last_student_has_left_establishment_payload }
+      let(:student) { Student.find_by(ine: last_ine) }
+
+      include_examples "closes the current schooling"
+    end
   end
 end


### PR DESCRIPTION
We had the column to enforce the fact that you can only have one current schooling (though I have a feeling this will eventually prove untrue), but really it's just a scope (`Schooling.current`) + has_one (has one `Schooling.current`) + a unique index (to enforce the deterministic result of said^ has_one).

Remove a bunch of logic around this, and some specs that were now failing for the right reasons.