### PR TITLE
db: backport the latest migration to PostgreSQL 14

### DIFF
--- a/db/migrate/20231112172554_remove_current_schooling_id_from_students.rb
+++ b/db/migrate/20231112172554_remove_current_schooling_id_from_students.rb
@@ -4,17 +4,14 @@ class RemoveCurrentSchoolingIdFromStudents < ActiveRecord::Migration[7.1]
   def up
     remove_reference :students, :current_schooling, foreign_key: { column: "current_schooling_id" }
 
-    execute <<~SQL.squish
-      CREATE UNIQUE INDEX one_active_schooling_per_student
-      ON schoolings(student_id, end_date)
-      NULLS NOT DISTINCT
-      WHERE (end_date IS NULL)
-    SQL
+    add_index :schoolings, :student_id, name: :one_active_schooling_per_student, unique: true, where: "end_date is null"
+    add_index :schoolings, %i[student_id classe_id], name: :one_schooling_per_class_student, unique: true
   end
 
   def down
     add_reference :students, :current_schooling, foreign_key: { to_table: :schoolings }
 
-    execute "DROP INDEX one_active_schooling_per_student"
+    remove_index :schoolings, name: :one_active_schooling_per_student
+    remove_index :schoolings, name: :one_schooling_per_class_student
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -169,8 +169,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_12_172554) do
     t.datetime "updated_at", null: false
     t.integer "attributive_decision_version", default: 0
     t.index ["classe_id"], name: "index_schoolings_on_classe_id"
-    t.index ["student_id", "end_date"], name: "one_active_schooling_per_student", unique: true, where: "(end_date IS NULL)", nulls_not_distinct: true
+    t.index ["student_id", "classe_id"], name: "one_schooling_per_class_student", unique: true
     t.index ["student_id"], name: "index_schoolings_on_student_id"
+    t.index ["student_id"], name: "one_active_schooling_per_student", unique: true, where: "(end_date IS NULL)"
   end
 
   create_table "students", force: :cascade do |t|

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       - "/app/node_modules"
     entrypoint: ''
   db:
-    image: postgres
+    # Scalingo only goes up to 14
+    image: postgres:14
     environment:
       POSTGRES_PASSWORD: 'dummy'
       PGPORT: 5433


### PR DESCRIPTION
Problème de compatibilité entre le PostgreSQL 14 de Scalingo et notre dernière migration écrite sur PostgreSQL 16 ; voir le commit pour l'explication détaillée.