### PR TITLE
Fix/simplify parsing

### DIFF
--- a/app/models/schooling.rb
+++ b/app/models/schooling.rb
@@ -13,7 +13,16 @@ class Schooling < ApplicationRecord
 
   scope :current, -> { where(end_date: nil) }
 
-  validates :student_id, uniqueness: { conditions: -> { current } }
+  validates :student, uniqueness: { scope: :end_date }, if: :open?
+  validates :student, uniqueness: { scope: [:classe] }, if: :closed?
+
+  def closed?
+    end_date.present?
+  end
+
+  def open?
+    !closed?
+  end
 
   def attributive_decision_filename
     [

--- a/app/models/schooling.rb
+++ b/app/models/schooling.rb
@@ -14,7 +14,7 @@ class Schooling < ApplicationRecord
   scope :current, -> { where(end_date: nil) }
 
   validates :student, uniqueness: { scope: :end_date }, if: :open?
-  validates :student, uniqueness: { scope: [:classe] }, if: :closed?
+  validates :student, uniqueness: { scope: :classe }, if: :closed?
 
   def closed?
     end_date.present?

--- a/app/models/student/mappers/base.rb
+++ b/app/models/student/mappers/base.rb
@@ -12,24 +12,27 @@ class Student
       end
 
       def parse!
-        classes_with_students.each do |classe, students|
-          students.each do |student|
-            if !Schooling.find_by(classe: classe, student: student)
-              student.close_current_schooling!
-              Schooling.create(classe: classe, student: student)
-            end
+        group_by_classes.each do |classe, entries|
+          entries.each do |entry|
+            student = map_student!(entry)
+
+            next if student.nil? # ine == nil
+
+            map_schooling!(classe, student, entry)
           end
         end
 
-        check_schoolings!
         check_missing_students!
       end
 
-      def classes_with_students
+      def group_by_classes
         payload
           .group_by { |entry| map_classe!(entry) }
-          .reject { |classe, _attrs| classe.nil? }
-          .transform_values! { |student_attrs| map_students!(student_attrs) }
+          .except(nil)
+      end
+
+      def classes_with_students
+        group_by_classes.transform_values! { |student_attrs| map_students!(student_attrs) }
       end
 
       def map_classe!(entry)
@@ -72,31 +75,6 @@ class Student
 
       def map_student_attributes(attrs)
         self.class::StudentMapper.new.call(attrs)
-      end
-
-      def check_schoolings!
-        payload
-          .filter { |entry| student_has_left_class?(entry) && find_existing_student(entry) }
-          .map    { |entry| [entry, find_existing_student(entry)] }
-          .each   { |entry, student| student.close_current_schooling!(left_classe_at(entry)) }
-      end
-
-      def find_existing_student(entry)
-        Student.find_by(ine: map_student_attributes(entry)[:ine])
-      end
-
-      # the MEF codes from SYGNE and FREGATA all arrive with an extra
-      # character that seems to be used for academic vs national
-      # diplomas[1]. Chomp the extra bit since all of our MEFs (which
-      # we prepopulate through data/mefs.csv) are 10 characters long.
-      #
-      # [1]: https://bv.ac-nantes.fr/affelnet-lycee-resultatsetab/aide/104-ecr-formations.htm
-      def chop_mef_code(code)
-        code.chop
-      end
-
-      def student_has_left_class?(entry)
-        student_has_changed_class?(entry) || student_has_left_establishment?(entry)
       end
 
       def inspect

--- a/app/models/student/mappers/fregata.rb
+++ b/app/models/student/mappers/fregata.rb
@@ -47,22 +47,12 @@ class Student
         student_attrs
       end
 
-      def student_has_changed_class?(entry)
-        timestamp_past?(left_classe_at(entry))
-      end
-
-      def student_has_left_establishment?(entry)
-        timestamp_past?(entry["dateSortieEtablissement"])
+      def map_schooling!(classe, student, entry)
+        Schooling.find_or_create_by!(classe: classe, student: student, end_date: left_classe_at(entry))
       end
 
       def left_classe_at(entry)
         entry["dateSortieFormation"] || entry["dateSortieEtablissement"]
-      end
-
-      private
-
-      def timestamp_past?(value)
-        value.present? && Date.parse(value).past?
       end
     end
   end

--- a/app/models/student/mappers/sygne.rb
+++ b/app/models/student/mappers/sygne.rb
@@ -40,16 +40,12 @@ class Student
         end
       end
 
-      def student_has_changed_class?(entry)
-        entry["classe"].blank?
-      end
+      def map_schooling!(classe, student, _entry)
+        schooling = Schooling.find_or_initialize_by(classe: classe, student: student)
 
-      def student_has_left_establishment?(_entry)
-        false
-      end
+        student.close_current_schooling! if schooling != student.current_schooling
 
-      def left_classe_at(_entry)
-        nil # we don't know
+        schooling.save!
       end
     end
   end

--- a/spec/models/schooling_spec.rb
+++ b/spec/models/schooling_spec.rb
@@ -13,20 +13,26 @@ RSpec.describe Schooling do
   end
 
   describe "validations" do
-    let(:schooling) { create(:schooling) }
-
     describe "student_id" do
-      context "when there is another closed schooling" do
-        before { schooling.student.close_current_schooling! }
+      context "when there is another schooling" do
+        let!(:schooling) { create(:schooling) }
 
-        it "creates a new schooling" do
-          expect { create(:schooling, student: schooling.student) }.to change(described_class, :count).by(1)
+        context "with an end date" do
+          before { schooling.student.close_current_schooling! }
+
+          it "can create a new one" do
+            expect { create(:schooling, student: schooling.student) }.to change(described_class, :count).by(1)
+          end
         end
-      end
 
-      context "when there is an open schooling" do
-        it "raises an error" do
-          expect { create(:schooling, student: schooling.student) }.to raise_error(ActiveRecord::RecordInvalid)
+        context "without an end date" do
+          it "rejects the new one" do
+            expect { create(:schooling, student: schooling.student) }.to raise_error(ActiveRecord::RecordInvalid)
+          end
+
+          it "doesn't reject a closed schooling" do
+            expect { create(:schooling, :closed, student: schooling.student) }.to(change(described_class, :count).by(1))
+          end
         end
       end
     end

--- a/spec/models/student/mappers/sygne_spec.rb
+++ b/spec/models/student/mappers/sygne_spec.rb
@@ -6,19 +6,45 @@ require "./mock/factories/api_student"
 require "./spec/support/shared/student_mapper"
 
 describe Student::Mappers::Sygne do
+  let(:establishment) { create(:establishment, :with_fim_user) }
+  let(:normal_payload) { build_list(:sygne_student, 10, classe: "1MELEC") }
+
   it_behaves_like "a student mapper" do
-    let(:establishment) { create(:establishment, :with_fim_user) }
-    let(:normal_payload) { build_list(:sygne_student, 10, classe: "1MELEC") }
     let(:irrelevant_mefs_payload) { build_list(:sygne_student, 10, codeMef: "-1") }
     let(:nil_ine_payload) { normal_payload.push(build(:sygne_student, :no_ine)) }
-    let(:last_ine) { normal_payload.last["ine"] }
-    let(:last_student_has_changed_class_payload) do
-      normal_payload.dup.tap do |students|
-        students.last["classe"] = "some new class"
+  end
+
+  describe "schoolings reconciliation" do
+    subject(:mapper) { described_class.new(next_data, establishment) }
+
+    let(:student) { Student.find_by(ine: normal_payload.last["ine"]) }
+
+    before { described_class.new(normal_payload, establishment).parse! }
+
+    context "when a student has disappeared" do
+      let(:next_data) { normal_payload.dup.tap(&:pop) }
+
+      it "closes its current shooling" do
+        expect { mapper.parse! }.to change { student.reload.current_schooling }.to(nil)
       end
     end
 
-    # with SYGNE, a known student not present in the payload means they're gone
-    let(:last_student_has_left_establishment_payload) { normal_payload.dup.tap(&:pop) }
+    context "when a student is in a new class" do
+      let(:next_data) do
+        normal_payload.dup.tap do |students|
+          students.last["classe"] = "some new class"
+        end
+      end
+
+      it "closes its previous schoolings" do
+        expect { mapper.parse! }.to(change { student.reload.current_schooling })
+      end
+
+      it "creates a new one" do
+        mapper.parse!
+
+        expect(student.current_schooling.classe.label).to eq "some new class"
+      end
+    end
   end
 end

--- a/spec/support/shared/student_mapper.rb
+++ b/spec/support/shared/student_mapper.rb
@@ -2,32 +2,22 @@
 
 require "rails_helper"
 
-RSpec.shared_examples "closes the current schooling" do
-  it "closes the student's previous schooling" do
-    expect { next_mapper.parse! }.to(change { student.reload.current_schooling })
-  end
-
-  it "sets the end date on the previous schooling" do
-    expect { next_mapper.parse! }.to(change { student.schoolings.first.end_date })
-  end
-end
-
 RSpec.shared_examples "a student mapper" do
   subject(:mapper) { described_class.new(data, establishment) }
 
   context "with a normal payload" do
     let(:data) { normal_payload }
 
-    it "upserts the students" do
-      expect { 2.times { mapper.parse! } }.to change(Student, :count).by(data.length)
-    end
+    [Student, Schooling, Classe].each do |model|
+      it "changes the #{model} count" do
+        expect { mapper.parse! }.to change(model, :count)
+      end
 
-    it "upserts the schoolings" do
-      expect { 2.times { mapper.parse! } }.to change(Schooling.current, :count).by(data.length)
-    end
+      it "upserts the #{model}" do
+        mapper.parse!
 
-    it "upserts the classes" do
-      expect { 2.times { mapper.parse! } }.to change(Classe, :count).by_at_most(data.length)
+        expect { mapper.parse! }.not_to change(model, :count)
+      end
     end
   end
 
@@ -39,42 +29,21 @@ RSpec.shared_examples "a student mapper" do
     end
   end
 
+  context "when the payload contains irrelevant mefs" do
+    let(:data) { irrelevant_mefs_payload }
+
+    [Student, Schooling, Classe].each do |model|
+      it "does not change the #{model} count" do
+        expect { mapper.parse! }.not_to change(model, :count)
+      end
+    end
+  end
+
   context "when the payload is empty" do
     let(:data) { [] }
 
     it "doesn't crash" do
       expect { mapper.parse! }.not_to raise_error
-    end
-
-    context "when there are students in the establishments" do
-      before { described_class.new(normal_payload, establishment).parse! }
-
-      it "doesn't aggressively clean previous schoolings" do
-        expect { mapper.parse! }.not_to change(Schooling.current, :count)
-      end
-    end
-  end
-
-  describe "updates" do
-    subject(:next_mapper) { described_class.new(next_data, establishment) }
-
-    let(:data) { normal_payload }
-    let(:next_data) { update_payload }
-
-    before { mapper.parse! }
-
-    context "when a student has changed class" do
-      let(:next_data) { last_student_has_changed_class_payload }
-      let(:student) { Student.find_by(ine: last_ine) }
-
-      include_examples "closes the current schooling"
-    end
-
-    context "when a student has left the establishment" do
-      let(:next_data) { last_student_has_left_establishment_payload }
-      let(:student) { Student.find_by(ine: last_ine) }
-
-      include_examples "closes the current schooling"
     end
   end
 end


### PR DESCRIPTION
Simplification du parsing en arrêtant de vouloir que SYGNE et FREGATA se comporte pareil : 

* SYGNE est stateful : tout ce qui en arrive doit invalider le passé ;
* FREGATA ne l'est pas : toutes les données sont valides, inclus les schoolings finis/inactifs, etc.

