### PR TITLE
sygne: only request active students

### DIFF
--- a/app/api/student_api/sygne.rb
+++ b/app/api/student_api/sygne.rb
@@ -11,7 +11,9 @@ module StudentApi
     end
 
     def fetch!
-      authenticated_client!.get(endpoint).body
+      params = { "etat-scolarisation" => "true" }
+
+      authenticated_client!.get(endpoint, params).body
     end
 
     def fetch_student_data!(ine)

--- a/features/support/webmock.rb
+++ b/features/support/webmock.rb
@@ -1,19 +1,8 @@
 # frozen_string_literal: true
 
 require "webmock/cucumber"
-require "./mock/factories/api_student"
 
 Before do
-  stub_request(:get, ENV.fetch("APLYPRO_SYGNE_URL"))
-    .with(
-      headers: {
-        "Accept" => "*/*",
-        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-        "User-Agent" => "Ruby"
-      }
-    )
-    .to_return(status: 200, body: FactoryBot.build_list(:sygne_student, 10), headers: {})
-
   etab_fixture = Rails.root.join("mock/data/etab.json").read
   stub_request(:get, /#{ENV.fetch('APLYPRO_ESTABLISHMENTS_DATA_URL')}/)
     .with(

--- a/spec/support/webmock_helpers.rb
+++ b/spec/support/webmock_helpers.rb
@@ -36,6 +36,7 @@ module WebmockHelpers
 
       WebMock.stub_request(:get, url)
              .with(
+               query: { "etat-scolarisation" => true },
                headers: {
                  "Accept" => "*/*",
                  "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",


### PR DESCRIPTION
Suite à nos discussions avec Xavier, voici la version corrigée de l'appel à SYGNE qui ne demande que les élèves actifs.