### PR TITLE
students: refresh listings everything someone connects

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -34,7 +34,6 @@ module Users
 
       log_user_in!
       save_roles!
-      async_fetch_students!
       fetch_establishments!
       choose_redirect_page!
     end
@@ -113,6 +112,8 @@ module Users
     def choose_redirect_page!
       establishments = @user.establishments
 
+      fetch_students_for!(establishments)
+
       if establishments.many?
         clear_previous_establishment!
         @inhibit_nav = true
@@ -125,10 +126,8 @@ module Users
       end
     end
 
-    def async_fetch_students!
-      jobs = @mapper.establishments_in_responsibility.map { |e| FetchStudentsJob.new(e) }
-
-      ActiveJob.perform_all_later(jobs)
+    def fetch_students_for!(establishments)
+      ActiveJob.perform_all_later(establishments.map { |e| FetchStudentsJob.new(e) })
     end
 
     def fetch_establishments!

--- a/features/gestion_de_pfmp.feature
+++ b/features/gestion_de_pfmp.feature
@@ -59,7 +59,8 @@ Fonctionnalité: Le personnel de direction édite les PFMPs
     Alors la page contient "La PFMP de Marie Curie a bien été validée"
 
   Scénario: Le personnel autorisé ne peut pas valider une PFMP individuellement
-    Sachant que je me connecte en tant que personnel autorisé de l'établissement "DINUM"
+    Sachant que je me déconnecte
+    Et que je me connecte en tant que personnel autorisé de l'établissement "DINUM"
     Et que je passe l'écran d'accueil
     Et que je renseigne une PFMP de 3 jours pour "Marie Curie"
     Quand je clique sur "Voir la PFMP"

--- a/features/recuperation_eleves.feature
+++ b/features/recuperation_eleves.feature
@@ -18,3 +18,15 @@ Fonctionnalité: Le personnel de direction récupère correctement les élèves
     Et que toutes les tâches de fond sont terminées
     Quand je me rends sur la page d'accueil
     Alors le panneau "Décisions d'attribution" contient "0 / 10"
+
+  Scénario: Les listes sont rafraîchies à chaque connexion
+    Sachant que l'API SYGNE renvoie 10 élèves en "1MELEC" dont l'INE "test" pour l'établissement "DINUM"
+    Et que je me connecte en tant que personnel autorisé de l'établissement "DINUM"
+    Et que je passe l'écran d'accueil
+    Et que toutes les tâches de fond sont terminées
+    Et que je me déconnecte
+    Et que l'API SYGNE renvoie 10 élèves en "TERM ELEC" dont l'INE "test" pour l'établissement "DINUM"
+    Quand je me connecte en tant que personnel MENJ
+    Et que toutes les tâches de fond sont terminées
+    Et que je consulte la liste des classes
+    Alors la page contient "TERM ELEC"

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -139,7 +139,9 @@ end
 
 Sachantque("je me connecte en tant que personnel autorisé de l'établissement {string}") do |uai|
   steps %(
-    Quand j'autorise "marie.curie@education.gouv.fr" à rejoindre l'application
+    Quand je suis un personnel MENJ directeur de l'établissement "#{uai}"
+    Et que je me connecte en tant que personnel MENJ
+    Et que j'autorise "marie.curie@education.gouv.fr" à rejoindre l'application
     Et que je me déconnecte
     Et que je suis un personnel MENJ de l'établissement "#{uai}" avec l'email "marie.curie@education.gouv.fr"
     Et que je me connecte en tant que personnel MENJ


### PR DESCRIPTION
We've got some data issues that are automatically fixed on the next parsing of the students payload.

More broadly, since a lot of personnel is delegated on the app and we were only refreshing when directors connect, it makes sense to do it on anybody's sucessful authentication into the system.