### PR TITLE
pfpms: avoid a crash when deleting a PMFP that's already gone

### DIFF
--- a/app/controllers/pfmps_controller.rb
+++ b/app/controllers/pfmps_controller.rb
@@ -65,6 +65,8 @@ class PfmpsController < ApplicationController
   end
 
   def confirm_deletion
+    redirect_to class_student_path(@classe, @student) and return if @pfmp.nil?
+
     add_breadcrumb(
       t("pages.titles.pfmps.show", name: @student.full_name),
       class_student_pfmp_path(@classe, @student, @pfmp)


### PR DESCRIPTION
1. someone clicks "Delete the PFMP" ;
2. we show them the confirmation screen ;
3. they go "Yes, delete"
4. we delete and redirect them to the student's profile ;
5. they hit the back button in their browser to go back to... the student's profile ;
6. we crash because that PFMP is gone.

Fixed.