### PR TITLE
api: don't rely on directors to figure out which API to call

### DIFF
--- a/app/api/student_api.rb
+++ b/app/api/student_api.rb
@@ -14,7 +14,7 @@ module StudentApi
       # maybe we should store the provider straight into the
       # establishment? see `mock/data/etab.json` for an example of the
       # "ministere_tutelle" attribute.
-      provider = establishment.users.directors.first.provider
+      provider = establishment.users.first.provider
 
       case provider
       when "fim"


### PR DESCRIPTION
Now that we have DELEG-CE enabled, it means we can get establishments without directors linked to them: if I'm a director I can give access to someone, and they'll connect without me.

Remove the assumption that there is a director to figure out which provider to use.