### PR TITLE
sygne: don't crash on a missing national MEF code

### DIFF
--- a/app/models/student/mappers/sygne.rb
+++ b/app/models/student/mappers/sygne.rb
@@ -34,6 +34,8 @@ class Student
 
           rename_keys(codeMefRatt: :mef_code, classe: :label)
 
+          map_value(:mef_code, Dry::Transformer::Coercions[:to_string])
+
           map_value :mef_code, ->(value) { value.chop }
 
           accept_keys %i[label mef_code]

--- a/spec/models/student/mappers/sygne_spec.rb
+++ b/spec/models/student/mappers/sygne_spec.rb
@@ -66,4 +66,14 @@ describe Student::Mappers::Sygne do
       end
     end
   end
+
+  describe "when there is no national MEF code" do
+    subject(:mapper) { described_class::ClasseMapper }
+
+    let(:entry) { build(:sygne_student, mef: nil) }
+
+    it "ignores the entry" do
+      expect { mapper.new.call(entry) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
Now that we look at the national MEF code (`codeMefRatt`) rather than the specialised one (`codeMef`), it turns out we sometimes get payload without `codeMefRatt`, which makes the parser crash. That crash is handled gracefully and reported into Sentry, but the issue is frequent enough to produce a fix: coercing the mef code into a string before attempting to chop it.