### PR TITLE
fregata: re-enable students to change establishments

### DIFF
--- a/app/models/student/mappers/fregata.rb
+++ b/app/models/student/mappers/fregata.rb
@@ -53,6 +53,8 @@ class Student
 
         schooling.end_date = left_classe_at(entry)
 
+        student.close_current_schooling! if schooling.open? && student.current_schooling != schooling
+
         schooling.save!
       end
 

--- a/spec/support/shared/student_mapper.rb
+++ b/spec/support/shared/student_mapper.rb
@@ -78,4 +78,18 @@ RSpec.shared_examples "a student mapper" do
       expect { mapper.parse! }.not_to raise_error
     end
   end
+
+  context "when a student is received in a new establishment" do
+    let(:data) { normal_payload }
+    let(:student) { Student.first }
+    let(:new_mapper) { described_class.new(data, create(:establishment)) }
+
+    before do
+      mapper.parse!
+    end
+
+    it "creates a new active schooling" do
+      expect { new_mapper.parse! }.to(change { student.reload.current_schooling })
+    end
+  end
 end


### PR DESCRIPTION
in our parsing logic rewrite some days ago we stepped away (at least we tried) from the temporal aspect of FREGATA because it returns all the schoolings for each student... in the requested establishment.

In other words, we still have to do some "close the previous schooling if necessary" logic in case a new establishment registers the student, which is now properly adressed.

Closes #241 