### PR TITLE
students: disable looking at a student that has left the class

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -13,7 +13,9 @@ class StudentsController < ClassesController
   private
 
   def set_student
-    @student = @classe.students.includes(:rib, :pfmps).find(params[:id])
+    @student = @classe.active_students.includes(:rib, :pfmps).find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to @classe, alert: t("errors.students.not_found")
   end
 
   def set_classe

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -27,6 +27,9 @@ fr:
   errors:
     classes:
       not_found: "La classe que vous avez demandée n'existe pas."
+    students:
+      not_found: "L'élève demandé n'est pas ou plus dans cette classe."
+
   activerecord:
     errors:
       models:
@@ -130,7 +133,7 @@ fr:
       no_access_found:
         title: "Erreur d'authentification"
         content: |
-          Le guichet d'authentification n'indique pas d'établissement concerné par l'allocation sous votre responsabilité, ni d'autorisations pour votre adresse e-mail. 
+          Le guichet d'authentification n'indique pas d'établissement concerné par l'allocation sous votre responsabilité, ni d'autorisations pour votre adresse e-mail.
           <ul>
             <li>Si vous êtes chef d'établissement, assurez-vous que vous avez bien ce rôle dans votre annuaire académique ou COLENTAGRI.</li>
             <li>Si vous n'êtes pas chef d'établissement assurez-vous que votre adresse e-mail a bien été autorisée par votre personnel de direction dans l'application APlyPro (ou via DELEG-CE).</li>

--- a/spec/requests/students_controller_spec.rb
+++ b/spec/requests/students_controller_spec.rb
@@ -26,5 +26,15 @@ RSpec.describe "StudentsControllers" do
 
       it { is_expected.to redirect_to classes_path }
     end
+
+    context "when trying to access a student that has left the establishment" do
+      before do
+        student.close_current_schooling!
+
+        get class_student_path(class_id: schooling.classe.id, id: schooling.student.id)
+      end
+
+      it { is_expected.to redirect_to class_path(schooling.classe) }
+    end
   end
 end


### PR DESCRIPTION
We don't display them in the class listing but the URL was still valid to look at the student and operate a mix of operations that will actually affect the new schooling...

Closes #243.