### PR TITLE
auth: fix display of RecordInvalid in authentication_failure

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -141,6 +141,9 @@ fr:
             <li>Si vous êtes chef d'établissement, assurez-vous que vous avez bien ce rôle dans votre annuaire académique ou COLENTAGRI.</li>
             <li>Si vous n'êtes pas chef d'établissement assurez-vous que votre adresse e-mail a bien été autorisée par votre personnel de direction dans l'application APlyPro (ou via DELEG-CE).</li>
           </ul>
+      record_invalid:
+        title: "Erreur lors du traitement de votre profil utilisateur"
+        content: "L'équipe technique a été notifiée du problème."
 
     success: "Connexion réussie"
 


### PR DESCRIPTION
We received this screenshot, that made me realise we have a missing translation for the `ActiveRecord::RecordInvalid` in `OmniauthCallbacksController`

![image (29)](https://github.com/betagouv/aplypro/assets/6117264/47810aab-793b-4a29-b84a-cd9defecaa66)
