### PR TITLE
pfmps: don't crash when trying to access a missing PFMPs

### DIFF
--- a/app/controllers/pfmps_controller.rb
+++ b/app/controllers/pfmps_controller.rb
@@ -92,7 +92,9 @@ class PfmpsController < ApplicationController
   end
 
   def set_pfmp
-    @pfmp = @student.pfmps.find_by(id: params[:id])
+    @pfmp = @student.pfmps.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    redirect_to class_student_path(@classe, @student), alert: t("errors.pfmps.not_found") and return
   end
 
   def set_student

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -32,7 +32,8 @@ fr:
       not_found: "La classe que vous avez demandée n'existe pas."
     students:
       not_found: "L'élève demandé n'est pas ou plus dans cette classe."
-
+    pfmps:
+      not_found: "La PFMP demandée n'est plus disponible ou a été supprimée."
   activerecord:
     errors:
       models:

--- a/spec/requests/pfmps_controller_spec.rb
+++ b/spec/requests/pfmps_controller_spec.rb
@@ -27,6 +27,16 @@ RSpec.describe "PfmpsController" do
 
       it { is_expected.to redirect_to classes_path }
     end
+
+    context "when trying to access a deleted PFMP" do
+      before do
+        pfmp.destroy!
+
+        get class_student_pfmp_path(class_id: schooling.classe.id, student_id: schooling.student.id, id: pfmp.id)
+      end
+
+      it { is_expected.to redirect_to class_student_path(schooling.classe, student) }
+    end
   end
 
   describe "POST /validate" do


### PR DESCRIPTION
As seen before, our users heavily rely on the back button of their browser, which means they'll delete things and then go back via the browser, crashing our controller who's expecting valid user paths. Fix like we did before for classes and students.