### PR TITLE
student: add with_rib/address scopes

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -28,7 +28,24 @@ class Student < ApplicationRecord
 
   has_one :rib, -> { where(archived_at: nil) }, dependent: :destroy, inverse_of: :student
 
+  scope :with_rib, -> { joins(:rib) }
+
+  scope :with_address, lambda {
+    where.not(address_line1: nil)
+         .where.not(address_line2: nil)
+         .where.not(postal_code: nil)
+         .where.not(country_code: nil)
+         .where.not(city: nil)
+  }
+
   before_validation :check_asp_file_reference
+
+  ADDRESS_FIELDS = %i[
+    address_line1
+    address_line2
+    postal_code
+    city
+  ].freeze
 
   def to_s
     full_name
@@ -55,12 +72,7 @@ class Student < ApplicationRecord
   end
 
   def address
-    [
-      address_line1,
-      address_line2,
-      postal_code,
-      city
-    ].compact.join(", ")
+    ADDRESS_FIELDS.map { |field| self[field] }.compact.join(", ")
   end
 
   def missing_address?

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -32,7 +32,7 @@ class Student < ApplicationRecord
 
   scope :with_address, lambda {
     where.not(address_line1: nil)
-         .where.not(address_line2: nil)
+         .or(where.not(address_line2: nil))
          .where.not(postal_code: nil)
          .where.not(country_code: nil)
          .where.not(city: nil)

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
       city { Faker::Address.city }
       country_code { Faker::Number.digit }
     end
+
+    trait :with_rib do
+      rib
+    end
   end
 end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -9,7 +9,6 @@ FactoryBot.define do
 
     trait :with_address do
       address_line1 { Faker::Address.street_name }
-      address_line2 { Faker::Address.street_name }
       postal_code { Faker::Address.zip_code }
       city_insee_code { Faker::Number.digit }
       city { Faker::Address.city }

--- a/spec/models/student_spec.rb
+++ b/spec/models/student_spec.rb
@@ -87,4 +87,26 @@ RSpec.describe Student do
       end
     end
   end
+
+  describe "scopes" do
+    %w[rib address].each do |attr|
+      scope = "with_#{attr}"
+
+      describe scope do
+        subject { described_class.send(scope) }
+
+        context "when the student has a #{attr}" do
+          let(:student) { create(:student, scope) }
+
+          it { is_expected.to include student }
+        end
+
+        context "when the student does not have a #{attr}" do
+          let(:student) { create(:student) }
+
+          it { is_expected.not_to include student }
+        end
+      end
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,9 +58,6 @@ RSpec.configure do |config|
 
   config.include Devise::Test::IntegrationHelpers, type: :request
 
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{Rails.root}/spec/fixtures"
-
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
   # instead of true.


### PR DESCRIPTION
Part of our criteria to send a payment forward will include: do we have your bank coordinates and the necessary information required by the ASP (just the address for now, will include birthday/place and everything else later).