### PR TITLE
api: decouple the StudentApi from establishments

### DIFF
--- a/app/api/student_api.rb
+++ b/app/api/student_api.rb
@@ -2,23 +2,20 @@
 
 module StudentApi
   class << self
-    def fetch_students!(establishment)
-      api_for(establishment).fetch_and_parse!
+    def fetch_students!(provider, uai)
+      api_for(provider, uai).fetch_and_parse!
     end
 
-    def fetch_student_data!(student)
-      api_for(student.current_schooling.establishment).fetch_student_data!(student.ine)
+    def fetch_student_data!(provider, uai, ine)
+      api_for(provider, uai).fetch_student_data!(ine)
     end
 
-    def api_for(establishment)
-      case establishment.students_provider
-      when "sygne"
-        Sygne.new(establishment)
-      when "fregata"
-        Fregata.new(establishment)
-      else
-        raise "Provider has no matching API"
-      end
+    def api_for(provider, uai)
+      klass = "StudentApi::#{provider.capitalize}".constantize
+
+      klass.new(uai)
+    rescue NameError
+      raise "no matching API found for #{provider}"
     end
   end
 end

--- a/app/api/student_api/base.rb
+++ b/app/api/student_api/base.rb
@@ -2,10 +2,10 @@
 
 module StudentApi
   class Base
-    attr_reader :establishment
+    attr_reader :uai
 
-    def initialize(establishment)
-      @establishment = establishment
+    def initialize(uai)
+      @uai = uai
     end
 
     def base_url
@@ -20,8 +20,8 @@ module StudentApi
       @response ||= fetch!
     end
 
-    def parse
-      mapper.new(response, establishment).parse!
+    def fetch_and_parse!
+      mapper.new(response, uai).parse!
     end
 
     def address_mapper
@@ -33,13 +33,11 @@ module StudentApi
     end
 
     def inspect
-      "#{self.class.name}: #{establishment.uai}"
+      "#{self.class.name}: #{uai}"
     end
 
     def clear!
       @response = nil
     end
-
-    alias fetch_and_parse! parse
   end
 end

--- a/app/api/student_api/fregata.rb
+++ b/app/api/student_api/fregata.rb
@@ -17,7 +17,7 @@ module StudentApi
     def fetch!
       @now = DateTime.now.httpdate
 
-      params = { rne: @establishment.uai, anneeScolaireId: fregata_year }
+      params = { rne: @uai, anneeScolaireId: fregata_year }
       headers = { "Authorization" => signature_header, "Date" => @now }
 
       client.get(endpoint, params, headers).body

--- a/app/api/student_api/sygne.rb
+++ b/app/api/student_api/sygne.rb
@@ -3,7 +3,7 @@
 module StudentApi
   class Sygne < Base
     def endpoint
-      base_url + format("etablissements/%s/eleves/", @establishment.uai)
+      base_url + format("etablissements/%s/eleves/", uai)
     end
 
     def student_endpoint(ine)

--- a/app/jobs/fetch_student_address_job.rb
+++ b/app/jobs/fetch_student_address_job.rb
@@ -4,7 +4,9 @@ class FetchStudentAddressJob < ApplicationJob
   queue_as :default
 
   def perform(student)
-    api = StudentApi.api_for(student.current_schooling.establishment)
+    establishment = student.current_schooling.establishment
+
+    api = StudentApi.api_for(establishment.students_provider, establishment.uai)
 
     api
       .fetch_student_data!(student.ine)

--- a/app/jobs/fetch_students_job.rb
+++ b/app/jobs/fetch_students_job.rb
@@ -16,6 +16,6 @@ class FetchStudentsJob < ApplicationJob
   end
 
   def perform(establishment)
-    StudentApi.fetch_students!(establishment)
+    StudentApi.fetch_students!(establishment.students_provider, establishment.uai)
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -221,10 +221,10 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_08_091401) do
 
   create_table "wages", force: :cascade do |t|
     t.integer "daily_rate", null: false
+    t.string "mefstat4", null: false
     t.integer "yearly_cap", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "mefstat4", null: false
     t.integer "ministry", null: false
     t.jsonb "mef_codes"
   end

--- a/spec/api/student_api/fregata_spec.rb
+++ b/spec/api/student_api/fregata_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe StudentApi::Fregata do
-  subject(:api) { described_class.new(establishment) }
+  subject(:api) { described_class.new(establishment.uai) }
 
   let(:establishment) { create(:establishment, :fregata_provider) }
 

--- a/spec/api/student_api/sygne_spec.rb
+++ b/spec/api/student_api/sygne_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 require "./mock/factories/api_student"
 
 describe StudentApi::Sygne do
-  subject(:api) { described_class.new(establishment) }
+  subject(:api) { described_class.new(establishment.uai) }
 
   let(:establishment) { create(:establishment, :sygne_provider) }
   let(:payload) { JSON.generate({ access_token: "foobar", token_type: "Bearer" }) }

--- a/spec/api/student_api_spec.rb
+++ b/spec/api/student_api_spec.rb
@@ -3,27 +3,23 @@
 require "rails_helper"
 
 describe StudentApi do
-  context "when asked for a FIM establishment" do
-    let(:etab) { create(:establishment, :sygne_provider) }
+  describe ".api_for" do
+    subject(:api_for) { described_class.api_for(provider, "123") }
 
-    it "uses an instance of the SYGNE API" do
-      expect(described_class.api_for(etab)).to be_a StudentApi::Sygne
+    %w[sygne fregata].each do |provider|
+      context "when asked for a #{provider.upcase} API" do
+        let(:provider) { provider }
+
+        it { is_expected.to be_a "StudentApi::#{provider.capitalize}".constantize }
+      end
     end
-  end
 
-  context "when asked for a MASA establishment" do
-    let(:etab) { create(:establishment, :fregata_provider) }
+    context "when asked for an unknown provider" do
+      let(:provider) { "foobar" }
 
-    it "uses an instance of the Fregata API" do
-      expect(described_class.api_for(etab)).to be_a StudentApi::Fregata
-    end
-  end
-
-  context "when asked for an unknown provider" do
-    let(:etab) { create(:establishment, students_provider: nil) }
-
-    it "raises an error" do
-      expect { described_class.fetch_students!(etab) }.to raise_error(/no matching API/)
+      it "raises an error" do
+        expect { api_for }.to raise_error(/no matching API/)
+      end
     end
   end
 end

--- a/spec/jobs/fetch_students_job_spec.rb
+++ b/spec/jobs/fetch_students_job_spec.rb
@@ -5,16 +5,16 @@ require "rails_helper"
 RSpec.describe FetchStudentsJob do
   include ActiveJob::TestHelper
 
-  let(:etab) { create(:establishment, :sygne_provider) }
+  let(:establishment) { create(:establishment, :sygne_provider) }
 
   before do
     allow(StudentApi).to receive(:fetch_students!)
   end
 
   it "calls the matchingStudentApi proxy" do
-    described_class.perform_now(etab)
+    described_class.perform_now(establishment)
 
-    expect(StudentApi).to have_received(:fetch_students!).with(etab)
+    expect(StudentApi).to have_received(:fetch_students!).with("sygne", establishment.uai)
   end
 
   context "when the underlying API fails" do
@@ -24,7 +24,7 @@ RSpec.describe FetchStudentsJob do
 
     it "rescues and retry" do
       perform_enqueued_jobs do
-        described_class.perform_now(etab)
+        described_class.perform_now(establishment)
       rescue Faraday::UnauthorizedError # rubocop:disable Lint/SuppressedException
       end
 

--- a/spec/models/student/mappers/fregata_spec.rb
+++ b/spec/models/student/mappers/fregata_spec.rb
@@ -9,6 +9,7 @@ describe Student::Mappers::Fregata do
   subject(:mapper) { described_class }
 
   let(:establishment) { create(:establishment, :fregata_provider) }
+  let(:uai) { establishment.uai }
   let(:normal_payload) { build_list(:fregata_student, 2) }
 
   it_behaves_like "a student mapper" do
@@ -24,7 +25,7 @@ describe Student::Mappers::Fregata do
   end
 
   it "also grabs the address" do
-    mapper.new(normal_payload, establishment).parse!
+    mapper.new(normal_payload, uai).parse!
 
     expect(Student.all.map(&:missing_address?).uniq).to contain_exactly false
   end
@@ -33,7 +34,7 @@ describe Student::Mappers::Fregata do
     let(:data) { build_list(:fregata_student, 1, :left_establishment, left_at: 3.days.ago, ine: "test") }
 
     it "sets the correct end date on the previous schooling" do
-      mapper.new(data, establishment).parse!
+      mapper.new(data, uai).parse!
 
       expect(Student.find_by(ine: "test").schoolings.last.end_date).to eq 3.days.ago.to_date
     end
@@ -43,7 +44,7 @@ describe Student::Mappers::Fregata do
     let(:data) { build_list(:fregata_student, 1, :left_classe, left_classe_at: 4.days.ago, ine: "test") }
 
     it "sets the correct end date on the previous schooling" do
-      mapper.new(data, establishment).parse!
+      mapper.new(data, uai).parse!
 
       expect(Student.find_by(ine: "test").schoolings.last.end_date).to eq 4.days.ago.to_date
     end
@@ -57,10 +58,10 @@ describe Student::Mappers::Fregata do
         ]
       end
 
-      before { mapper.new(previous_data, establishment).parse! }
+      before { mapper.new(previous_data, uai).parse! }
 
       it "updates the end date in place" do
-        expect { mapper.new(data, establishment).parse! }.to change(Schooling.current, :count).by(-1)
+        expect { mapper.new(data, uai).parse! }.to change(Schooling.current, :count).by(-1)
       end
     end
   end
@@ -75,7 +76,7 @@ describe Student::Mappers::Fregata do
       ]
     end
 
-    before { mapper.new(data, establishment).parse! }
+    before { mapper.new(data, uai).parse! }
 
     it "parses them correctly" do
       expect(student.schoolings).to have(2).schoolings
@@ -90,11 +91,11 @@ describe Student::Mappers::Fregata do
     let(:data) { [build(:fregata_student, :left_establishment)] }
 
     it "parses the student" do
-      expect { mapper.new(data, establishment).parse! }.to change(Student, :count).by(1)
+      expect { mapper.new(data, uai).parse! }.to change(Student, :count).by(1)
     end
 
     it "closes the schooling straight away" do
-      expect { mapper.new(data, establishment).parse! }.not_to change(Schooling.current, :count)
+      expect { mapper.new(data, uai).parse! }.not_to change(Schooling.current, :count)
     end
   end
 end

--- a/spec/models/student/mappers/sygne_spec.rb
+++ b/spec/models/student/mappers/sygne_spec.rb
@@ -6,7 +6,7 @@ require "./mock/factories/api_student"
 require "./spec/support/shared/student_mapper"
 
 describe Student::Mappers::Sygne do
-  let(:establishment) { create(:establishment, :sygne_provider) }
+  let(:uai) { create(:establishment, :sygne_provider).uai }
   let(:normal_payload) { build_list(:sygne_student, 10, classe: "1MELEC") }
 
   it_behaves_like "a student mapper" do
@@ -23,11 +23,11 @@ describe Student::Mappers::Sygne do
   end
 
   describe "schoolings reconciliation" do
-    subject(:mapper) { described_class.new(next_data, establishment) }
+    subject(:mapper) { described_class.new(next_data, uai) }
 
     let(:student) { Student.find_by(ine: normal_payload.last["ine"]) }
 
-    before { described_class.new(normal_payload, establishment).parse! }
+    before { described_class.new(normal_payload, uai).parse! }
 
     context "when a student has disappeared" do
       let(:next_data) { normal_payload.dup.tap(&:pop) }

--- a/spec/support/shared/student_mapper.rb
+++ b/spec/support/shared/student_mapper.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.shared_examples "a student mapper" do
-  subject(:mapper) { described_class.new(data, establishment) }
+  subject(:mapper) { described_class.new(data, uai) }
 
   context "with a normal payload" do
     let(:data) { normal_payload }
@@ -33,7 +33,7 @@ RSpec.shared_examples "a student mapper" do
     let(:data) { nil_ine_payload }
 
     it "doesn't crash on students without an INE" do
-      expect { described_class.new(nil_ine_payload, establishment).parse! }.not_to raise_error
+      expect { described_class.new(nil_ine_payload, uai).parse! }.not_to raise_error
     end
   end
 
@@ -82,7 +82,7 @@ RSpec.shared_examples "a student mapper" do
   context "when a student is received in a new establishment" do
     let(:data) { normal_payload }
     let(:student) { Student.first }
-    let(:new_mapper) { described_class.new(data, create(:establishment)) }
+    let(:new_mapper) { described_class.new(data, create(:establishment).uai) }
 
     before do
       mapper.parse!


### PR DESCRIPTION
ndlr: description tiré de l'unique commit, mais relates to #264 

StudentAPI shouldn't know about what an establishment looks like: it specialises for a certain provider (SYGNE or FREGATA) and then it queries an UAI, that's it.

The job, because it is passed an establishment, can happily deconstruct the right arguments and pass them plain to the StudentAPI. This will pay-off because it's Good Design®, and also because we'll soon have to worry about establishments that need to get students from both sources.

The interface is simpler with the decoupling:

```ruby
 # new api
StudentApi.api_for("sygne", "123") # can be queried and inspected
StudentApi.api_for("fregata", "123") # idem

 # compare with previous api
StudentApi.api_for(double_sourced_establishment) # how do you inspect?
```