### PR TITLE
payments: add a "ready" state

### DIFF
--- a/app/models/payment.rb
+++ b/app/models/payment.rb
@@ -20,12 +20,16 @@ class Payment < ApplicationRecord
     )
   end
 
+  def mark_ready!
+    state_machine.transition_to!(:ready)
+  end
+
   def process!
     state_machine.transition_to!(:processing)
   end
 
   def complete!
-    state_machine.transition_to!(:success)
+    state_machine.transition_to!(:successful)
   end
 
   def fail!

--- a/app/models/payment_state_machine.rb
+++ b/app/models/payment_state_machine.rb
@@ -4,11 +4,13 @@ class PaymentStateMachine
   include Statesman::Machine
 
   state :pending, initial: true
+  state :ready
   state :processing
-  state :success
+  state :successful
   state :failed
 
-  transition from: :pending, to: :processing
-  transition from: :processing, to: :success
+  transition from: :pending, to: :ready
+  transition from: :ready, to: :processing
+  transition from: :processing, to: :successful
   transition from: :processing, to: :failed
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -43,7 +43,7 @@ class Student < ApplicationRecord
   end
 
   def used_allowance
-    payments.in_state(:success).map(&:amount).sum
+    payments.in_state(:successful).map(&:amount).sum
   end
 
   def allowance_left

--- a/spec/factories/payments.rb
+++ b/spec/factories/payments.rb
@@ -5,7 +5,13 @@ FactoryBot.define do
     pfmp
     amount { Faker::Number.positive }
 
+    trait :ready do
+      after(:create, &:mark_ready!)
+    end
+
     trait :processing do
+      ready
+
       after(:create, &:process!)
     end
 

--- a/spec/models/payment_spec.rb
+++ b/spec/models/payment_spec.rb
@@ -12,21 +12,5 @@ RSpec.describe Payment do
     it "starts in created state" do
       expect(payment.state_machine).to be_in_state "pending"
     end
-
-    context "when the process! method is called" do
-      it "moves to processed" do
-        expect { payment.process! }.to change(payment, :current_state).from("pending").to("processing")
-      end
-    end
-
-    context "when the complete! method is called" do
-      before do
-        payment.process!
-      end
-
-      it "moves to successful" do
-        expect { payment.complete! }.to change(payment, :current_state).from("processing").to("success")
-      end
-    end
   end
 end

--- a/spec/models/pfmp_spec.rb
+++ b/spec/models/pfmp_spec.rb
@@ -132,9 +132,11 @@ RSpec.describe Pfmp do
 
     context "when the student has already reached the yearly cap" do
       before do
-        create(:pfmp, :validated, schooling: pfmp.schooling, day_count: 200).tap do |p|
-          p.latest_payment.transition_to!(:processing)
-          p.latest_payment.transition_to!(:success)
+        create(:pfmp, :validated, schooling: pfmp.schooling, day_count: 200).tap do |pfmp|
+          pfmp.latest_payment
+              .tap(&:mark_ready!)
+              .tap(&:process!)
+              .tap(&:complete!)
         end
       end
 


### PR DESCRIPTION
Here's the idea:

1. pending: the payment is due;
2. ready: the payment is ready to be sent, we have all the info;
3. processing: the payment has been sent;
4. successful: back from the payment gateway;
5. failed: back from the payment gateway.

The hard bits will be defining the logic between all these bits but in terms of abstraction it should be good enough for now (famous last words).