### PR TITLE
db: explicitly name the address fields

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -58,8 +58,8 @@ class Student < ApplicationRecord
     [
       address_line1,
       address_line2,
-      postal_code,
-      city
+      address_postal_code,
+      address_city
     ].compact.join(", ")
   end
 

--- a/app/models/student/address_mappers/fregata.rb
+++ b/app/models/student/address_mappers/fregata.rb
@@ -27,16 +27,16 @@ class Student
           unwrap :adresseIndividu
 
           rename_keys(
-            communeCodePostal: :postal_code,
-            paysCodeInsee: :country_code,
-            communeCodeInsee: :city_insee_code
+            communeCodePostal: :address_postal_code,
+            paysCodeInsee: :address_country_code,
+            communeCodeInsee: :address_city_insee_code
           )
 
           nest :address_line1, %i[ligne2 ligne3 ligne4 ligne5 ligne6 ligne7]
 
           map_value :address_line1, ->(hash) { hash.values.compact.join(" ") }
 
-          accept_keys %i[postal_code country_code city_insee_code address_line1]
+          accept_keys %i[address_postal_code address_country_code address_city_insee_code address_line1]
         end
       end
     end

--- a/app/models/student/address_mappers/sygne.rb
+++ b/app/models/student/address_mappers/sygne.rb
@@ -12,15 +12,22 @@ class Student
           unwrap :adrResidenceEle
 
           rename_keys(
-            codePostal: :postal_code,
+            codePostal: :address_postal_code,
             adresseLigne1: :address_line1,
             adresseLigne2: :address_line2,
-            codePays: :country_code,
-            codeCommuneInsee: :city_insee_code,
-            libelleCommune: :city
+            codePays: :address_country_code,
+            codeCommuneInsee: :address_city_insee_code,
+            libelleCommune: :address_city
           )
 
-          accept_keys %i[postal_code country_code city city_insee_code address_line1 address_line2]
+          accept_keys %i[
+            address_postal_code
+            address_country_code
+            address_city
+            address_city_insee_code
+            address_line1
+            address_line2
+          ]
         end
       end
     end

--- a/db/migrate/20240104101419_rename_address_fields_for_student.rb
+++ b/db/migrate/20240104101419_rename_address_fields_for_student.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class RenameAddressFieldsForStudent < ActiveRecord::Migration[7.1]
+  def change
+    change_table :students do |t|
+      t.rename :postal_code, :address_postal_code
+      t.rename :city_insee_code, :address_city_insee_code
+      t.rename :city, :address_city
+      t.rename :country_code, :address_country_code
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_08_091401) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_04_101419) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -188,10 +188,10 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_08_091401) do
     t.string "asp_file_reference", null: false
     t.string "address_line1"
     t.string "address_line2"
-    t.string "postal_code"
-    t.string "city_insee_code"
-    t.string "city"
-    t.string "country_code"
+    t.string "address_postal_code"
+    t.string "address_city_insee_code"
+    t.string "address_city"
+    t.string "address_country_code"
     t.index ["asp_file_reference"], name: "index_students_on_asp_file_reference", unique: true
     t.index ["ine"], name: "index_students_on_ine", unique: true
   end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -10,10 +10,10 @@ FactoryBot.define do
     trait :with_address do
       address_line1 { Faker::Address.street_name }
       address_line2 { Faker::Address.street_name }
-      postal_code { Faker::Address.zip_code }
-      city_insee_code { Faker::Number.digit }
-      city { Faker::Address.city }
-      country_code { Faker::Number.digit }
+      address_postal_code { Faker::Address.zip_code }
+      address_city_insee_code { Faker::Number.digit }
+      address_city { Faker::Address.city }
+      address_country_code { Faker::Number.digit }
     end
   end
 end

--- a/spec/jobs/fetch_student_address_job_spec.rb
+++ b/spec/jobs/fetch_student_address_job_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe FetchStudentAddressJob do
     describe "attributes mapping" do
       %i[
         address_line1
-        postal_code
-        city_insee_code
-        country_code
+        address_postal_code
+        address_city_insee_code
+        address_country_code
       ].each do |attribute|
         it "updates the `#{attribute}` attribute" do
           expect { described_class.new(student).perform_now }.to change(student, attribute)

--- a/spec/models/student/address_mappers/fregata_spec.rb
+++ b/spec/models/student/address_mappers/fregata_spec.rb
@@ -19,7 +19,7 @@ describe Student::AddressMappers::Fregata do
   describe "mapper" do
     let(:address) { data.first["adressesApprenant"] }
 
-    it { is_expected.to include({ postal_code: "34080" }) }
+    it { is_expected.to include({ address_postal_code: "34080" }) }
     it { is_expected.to include({ address_line1: "80 RUE DU TEST 34080 MONTPELLIER FRANCE" }) }
   end
 end

--- a/spec/models/student/address_mappers/sygne_spec.rb
+++ b/spec/models/student/address_mappers/sygne_spec.rb
@@ -20,9 +20,9 @@ describe Student::AddressMappers::Sygne do
 
     it { is_expected.to include(address_line1: line_one) }
     it { is_expected.to include(address_line2: line_two) }
-    it { is_expected.to include(city: city) }
-    it { is_expected.to include(city_insee_code: city_insee_code) }
-    it { is_expected.to include(country_code: country_code) }
+    it { is_expected.to include(address_city: city) }
+    it { is_expected.to include(address_city_insee_code: city_insee_code) }
+    it { is_expected.to include(address_country_code: country_code) }
   end
 end
 # rubocop:enable RSpec/MultipleMemoizedHelpers


### PR DESCRIPTION
In order to tackle https://github.com/betagouv/aplypro/issues/337, rename the address fields explicitly to avoid confusion with `birth_country_code` and `birth_city_code` (coming soon).