### PR TITLE
establishments: simplify the choose establishment filter logic

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,9 +24,13 @@ class ApplicationController < ActionController::Base
   end
 
   def set_establishment
-    @etab = current_user&.establishment
+    return unless user_signed_in?
 
-    redirect_to select_establishments_path and return if @etab.blank?
+    if current_user.establishment.nil?
+      redirect_to select_establishments_path
+    else
+      @etab = current_user&.establishment
+    end
   end
 
   def infer_page_title(attrs = {})

--- a/app/controllers/establishments_controller.rb
+++ b/app/controllers/establishments_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class EstablishmentsController < ApplicationController
-  skip_before_action :set_establishment, only: :select
-
   before_action :check_director,
                 :update_and_check_confirmed_director,
                 only: :create_attributive_decisions

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -3,7 +3,7 @@
 class HomeController < ApplicationController
   layout "maintenance", only: :maintenance
 
-  skip_before_action :authenticate_user!, :set_establishment, only: %i[maintenance index login]
+  skip_before_action :authenticate_user!, only: %i[maintenance index login]
 
   before_action :show_welcome_screen, only: :home
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,7 +5,7 @@ module Users
   class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     include DeveloperOidc
 
-    skip_before_action :verify_authenticity_token, :set_establishment
+    skip_before_action :verify_authenticity_token
 
     rescue_from IdentityMappers::Errors::Error, ActiveRecord::RecordInvalid, with: :authentication_failure
 


### PR DESCRIPTION
du commit:

> I believe (though it's late and my brain is fried) we need to
redirect to the choose-establishment page only if we have a current
user logged in, otherwise we don't really care. Using a single action
with that logic removes the need for filters in other controllers.