### PR TITLE
asp: add the PersonnePhysique XML entity

### DIFF
--- a/app/services/asp/entities/personne_physique.rb
+++ b/app/services/asp/entities/personne_physique.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module ASP
+  module Entities
+    class PersonnePhysique
+      include ActiveModel::API
+      include ActiveModel::Attributes
+      include ActiveModel::AttributeAssignment
+
+      attribute :titre, :string
+      attribute :sexe, :string
+      attribute :nomusage, :string
+      attribute :nomnaissance, :string
+      attribute :prenom, :string
+      attribute :datenaissance, :string
+      attribute :codeinseepaysnai, :string
+      attribute :codeinseecommune, :string
+
+      validates_presence_of %i[
+        titre
+        sexe
+        nomusage
+        nomnaissance
+        prenom
+        datenaissance
+        codeinseepaysnai
+        codeinseecommune
+      ]
+
+      def self.from_student(student)
+        mapper = ASP::Mappers::StudentMapper.new(student)
+
+        new.tap do |instance|
+          mapped_attributes = attribute_names.index_with { |attr| mapper.send(attr) }
+
+          instance.assign_attributes(mapped_attributes)
+        end
+      end
+
+      def to_xml(document = Nokogiri::XML::Document.new)
+        validate!
+
+        Nokogiri::XML::Builder.with(document) do |xml|
+          xml.personnephysique do
+            xml.titre(titre)
+            xml.prenom(prenom)
+            xml.nomusage(nomusage)
+          end
+        end.to_xml
+      end
+    end
+  end
+end

--- a/app/services/asp/mappers/student_mapper.rb
+++ b/app/services/asp/mappers/student_mapper.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module ASP
+  module Mappers
+    class StudentMapper
+      MAPPING = {
+        prenom: :first_name,
+        nomusage: :last_name,
+        nomnaissance: :last_name,
+        datenaissance: :birthdate,
+        sexe: :biological_sex,
+        codeinseepaysnai: :birthplace_country_insee_code,
+        codeinseecommune: :birthplace_city_insee_code
+      }.freeze
+
+      # yes, we know. It's 2024 and we're still doing this silly
+      # mapping but we're dealing with legacy systems that aren't
+      # aware yet that this is wrong, nor do our APIs provide any
+      # clues as to what the gender of our students might be.
+      GENDER_FOR_SEX = {
+        male: "MR",
+        female: "MME"
+      }.freeze
+
+      attr_reader :student
+
+      def initialize(student)
+        @student = student
+      end
+
+      MAPPING.each do |name, attr|
+        define_method(name) { student[attr] }
+      end
+
+      def titre
+        GENDER_FOR_SEX[student.biological_sex.to_sym]
+      end
+    end
+  end
+end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -7,6 +7,15 @@ FactoryBot.define do
     last_name { Faker::Name.last_name }
     birthdate { Faker::Date.birthday(min_age: 16, max_age: 20) }
 
+    trait :with_address_info do
+      with_address
+    end
+
+    trait :with_birthplace_info do
+      birthplace_city_insee_code { Faker::Number.digit }
+      birthplace_country_insee_code { Faker::Number.digit }
+    end
+
     trait :with_address do
       address_line1 { Faker::Address.street_name }
       address_line2 { Faker::Address.street_name }

--- a/spec/services/asp/entities/personne_physique_spec.rb
+++ b/spec/services/asp/entities/personne_physique_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ASP::Entities::PersonnePhysique do
+  describe ".from_student" do
+    subject(:model) { described_class.from_student(student) }
+
+    let(:student) { create(:student, :male, :with_address_info, :with_birthplace_info, first_name: "Marie") }
+
+    describe "to_xml" do
+      subject(:document) { Nokogiri::XML(described_class.from_student(student).to_xml) }
+
+      it "can generate some XML" do
+        expect(document.to_s).not_to be_empty
+      end
+
+      specify "prenom" do
+        expect(document.at("personnephysique/prenom")).to have_attributes(text: "Marie")
+      end
+    end
+  end
+end

--- a/spec/services/asp/mappers/student_mapper_spec.rb
+++ b/spec/services/asp/mappers/student_mapper_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe ASP::Mappers::StudentMapper do
+  subject(:mapper) { described_class.new(student) }
+
+  let(:student) { create(:student) }
+
+  described_class::MAPPING.each do |name, mapping|
+    it "maps to the student's`#{mapping}'" do
+      expect(mapper.send(name)).to eq student[mapping]
+    end
+  end
+end


### PR DESCRIPTION
Here's the gameplan: we're going to leverage the Active Model API to encode some of the ASP logic into the app rather than doing some on-the-fly mapping.

This means backporting a bunch of the SERAPIS logic to plain old Ruby objects (albeit extending Active Model) that:

1. declare attributes and possible validations ;
2. are able to be instantiated/mapped from our Active Record models ;
3. declare a `to_xml` method that can tack onto an existing builder object.

This should enable some form of validation chain to make sure we don't send garbage over.