### PR TITLE
attributive_decision: proper verb to show document, instead of download

### DIFF
--- a/app/views/students/show.html.haml
+++ b/app/views/students/show.html.haml
@@ -35,4 +35,4 @@
   .fr-btns-group.fr-btns-group--inline
     = link_to "Ajouter une PFMP", new_class_student_pfmp_path(@classe, @student), class: 'fr-btn'
     - if @student.current_schooling.attributive_decision.attached?
-      = link_to "Télécharger la décision d'attribution", url_for(@student.current_schooling.attributive_decision), class: 'fr-btn fr-btn--secondary', target: :download
+      = link_to "Voir la décision d'attribution", url_for(@student.current_schooling.attributive_decision), class: 'fr-btn fr-btn--secondary', target: :download


### PR DESCRIPTION
Au départ j'allais ajouter une mention que Roxanne avait suggéré (voir [cette carte](https://github.com/orgs/betagouv/projects/71/views/1?filterQuery=-status%3A%22TODO+Paiements%22&pane=issue&itemId=48771232)) mais en fait c'était déjà fait. Donc je sais pas si elle s'est trompé de texte, ou si c'était bien ça qu'elle voulait, je verrai avec elle lundi.

En tout cas au passage j'ai remarqué qu'un bouton n'avait pas le bon verbe, donc je l'ai changé dans cette mini PR.