### PR TITLE
app: standardise `current_establishment` instead of @etab

### DIFF
--- a/app/controllers/classes_controller.rb
+++ b/app/controllers/classes_controller.rb
@@ -80,7 +80,7 @@ class ClassesController < ApplicationController
   end
 
   def set_all_classes
-    @classes = @etab
+    @classes = current_establishment
                .classes
                .current
                .includes(:mef, :active_pfmps, active_students: :rib)
@@ -88,7 +88,7 @@ class ClassesController < ApplicationController
 
   def set_classe
     @classe = Classe
-              .where(establishment: @etab)
+              .where(establishment: current_establishment)
               .includes(active_schoolings: [student: :rib])
               .find(params[:id])
 

--- a/app/controllers/concerns/role_check.rb
+++ b/app/controllers/concerns/role_check.rb
@@ -17,9 +17,9 @@ module RoleCheck
 
   def update_confirmed_director!
     if params[:confirmed_director] == "1"
-      @etab.update(confirmed_director: current_user)
-    elsif @etab.confirmed_director == current_user
-      @etab.update(confirmed_director: nil)
+      current_establishment.update(confirmed_director: current_user)
+    elsif current_establishment.confirmed_director == current_user
+      current_establishment.update(confirmed_director: nil)
     end
   end
 end

--- a/app/controllers/establishments_controller.rb
+++ b/app/controllers/establishments_controller.rb
@@ -13,13 +13,13 @@ class EstablishmentsController < ApplicationController
   def create_attributive_decisions
     mark_attributive_decision_generation!
 
-    GenerateMissingAttributiveDecisionsJob.perform_later(@etab)
+    GenerateMissingAttributiveDecisionsJob.perform_later(current_establishment)
 
     redirect_to root_path
   end
 
   def download_attributive_decisions
-    documents = @etab
+    documents = current_establishment
                 .current_schoolings
                 .with_attached_attributive_decision
                 .map(&:attributive_decision)
@@ -36,14 +36,14 @@ class EstablishmentsController < ApplicationController
   end
 
   def attributive_decisions_archive_name
-    "#{@etab.uai}_décisions_d_attribution_#{Time.zone.today}.zip"
+    "#{current_establishment.uai}_décisions_d_attribution_#{Time.zone.today}.zip"
   end
 
   # FIXME: this isn't great but the job might not have actually kicked
   # in by the time the page is refreshed so trigger a synchronous DB
   # update to mark the generation process as started
   def mark_attributive_decision_generation!
-    @etab
+    current_establishment
       .schoolings
       .without_attributive_decisions
       .update_all(generating_attributive_decision: true) # rubocop:disable Rails/SkipsModelValidations

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -17,10 +17,10 @@ class HomeController < ApplicationController
     infer_page_title
     @inhibit_title = true
 
-    current_classes = @etab.classes.current
+    current_classes = current_establishment.classes.current
 
     @students_count = current_classes.joins(:active_students).count
-    @attributive_decisions_count = @etab.schoolings.current.joins(:attributive_decision_attachment).count
+    @attributive_decisions_count = current_establishment.schoolings.current.with_attributive_decisions.count
     @ribs_count = current_classes.joins(active_students: :rib).count
     @pfmps_counts = pfmp_counts
   end
@@ -51,7 +51,7 @@ class HomeController < ApplicationController
     pfmps = Pfmp
             .joins(:classe)
             .merge(Schooling.current)
-            .merge(@etab.classes.current)
+            .merge(current_establishment.classes.current)
 
     PfmpStateMachine.states.index_with { |state| pfmps.in_state(state).count }
   end

--- a/app/controllers/invitations_controller.rb
+++ b/app/controllers/invitations_controller.rb
@@ -6,7 +6,7 @@ class InvitationsController < ApplicationController
   before_action :add_new_breadcrumbs, only: %i[new create]
 
   def index
-    @invitations = @etab.invitations
+    @invitations = current_establishment.invitations
 
     infer_page_title
   end
@@ -28,7 +28,10 @@ class InvitationsController < ApplicationController
   def destroy
     @invitation.destroy
 
-    redirect_to establishment_invitations_path(@etab), notice: t("flash.invites.destroyed", email: @invitation.email)
+    redirect_to(
+      establishment_invitations_path(current_establishment),
+      notice: t("flash.invites.destroyed", email: @invitation.email)
+    )
   end
 
   private
@@ -37,11 +40,11 @@ class InvitationsController < ApplicationController
     params
       .require(:invitation)
       .permit(:email)
-      .with_defaults(user: current_user, establishment: @etab)
+      .with_defaults(user: current_user, establishment: current_establishment)
   end
 
   def set_invitation
-    @invitation = @etab.invitations.find(params[:id])
+    @invitation = current_establishment.invitations.find(params[:id])
   end
 
   def check_authorised_to_invite
@@ -55,7 +58,7 @@ class InvitationsController < ApplicationController
   end
 
   def add_new_breadcrumbs
-    add_breadcrumb t("pages.titles.invitations.index"), establishment_invitations_path(@etab)
+    add_breadcrumb t("pages.titles.invitations.index"), establishment_invitations_path(current_establishment)
     infer_page_title
   end
 end

--- a/app/controllers/pfmps_controller.rb
+++ b/app/controllers/pfmps_controller.rb
@@ -3,7 +3,6 @@
 class PfmpsController < ApplicationController
   include RoleCheck
 
-  before_action :authenticate_user!
   before_action :check_director, only: :validate
   before_action :set_classe, :set_student
   before_action :set_pfmp_breadcrumbs, except: :confirm_deletion
@@ -80,7 +79,7 @@ class PfmpsController < ApplicationController
   end
 
   def set_classe
-    @classe = Classe.where(establishment: @etab).find(params[:class_id])
+    @classe = Classe.where(establishment: current_establishment).find(params[:class_id])
   rescue ActiveRecord::RecordNotFound
     redirect_to classes_path, alert: t("errors.classes.not_found") and return
   end

--- a/app/controllers/ribs_controller.rb
+++ b/app/controllers/ribs_controller.rb
@@ -92,7 +92,7 @@ class RibsController < StudentsController
   end
 
   def set_classe
-    @classe = Classe.where(establishment: @etab).find(params[:class_id])
+    @classe = Classe.where(establishment: current_establishment).find(params[:class_id])
   rescue ActiveRecord::RecordNotFound
     redirect_to classes_path, alert: t("errors.classes.not_found"), status: :forbidden and return
   end

--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -6,7 +6,7 @@ class StudentsController < ClassesController
   def show
     add_breadcrumb t("pages.titles.classes.index"), classes_path
     add_breadcrumb @classe.to_s, class_path(@classe)
-    @pfmps = @student.pfmps.joins(:classe).where({ classe: { establishment: @etab } })
+    @pfmps = @student.pfmps.joins(:classe).where({ classe: { establishment: current_establishment } })
 
     infer_page_title(name: @student.full_name, classe: @classe)
   end
@@ -21,7 +21,7 @@ class StudentsController < ClassesController
 
   def set_classe
     @classe = Classe
-              .where(establishment: @etab)
+              .where(establishment: current_establishment)
               .find(params[:class_id])
   rescue ActiveRecord::RecordNotFound
     redirect_to classes_path, alert: t("errors.classes.not_found") and return

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
-  skip_before_action :set_establishment, only: :update
+  skip_before_action :check_current_establishment, only: :update
 
   def update
     @user = current_user

--- a/app/controllers/validations_controller.rb
+++ b/app/controllers/validations_controller.rb
@@ -52,7 +52,7 @@ class ValidationsController < ApplicationController
   end
 
   def set_classe
-    @classe = Classe.where(establishment: @etab).find(params[:id])
+    @classe = Classe.where(establishment: current_establishment).find(params[:id])
   rescue ActiveRecord::RecordNotFound
     redirect_to validations_path, alert: t("errors.classes.not_found") and return
   end
@@ -61,7 +61,7 @@ class ValidationsController < ApplicationController
     Pfmp
       .in_state(:completed)
       .joins(classe: :establishment)
-      .where(classe: { establishment: @etab })
+      .where(classe: { establishment: current_establishment })
       .merge(Schooling.current)
   end
 

--- a/app/views/classes/_attributive_decisions_panel.html.haml
+++ b/app/views/classes/_attributive_decisions_panel.html.haml
@@ -6,11 +6,11 @@
 %p La décision d'attribution annuelle rend éligible l'élève à percevoir l'allocation. Ce document doit obligatoirement être transmis à l'élève et conservé toute l'année scolaire et il doit être archivé par l'établissement pendant une durée de 10 ans en cas de contrôle de la chaîne des dépenses publiques.
 
 
-- if @etab.some_attributive_decisions_generating?
+- if current_establishment.some_attributive_decisions_generating?
   = dsfr_alert(type: :info, title: "Édition des décisions d'attribution en cours", classes: 'fr-mt-3w') do
     %p Les décisions d'attribution sont en train d'être éditées, veuillez rafraichir la page dans quelques minutes. Vous pouvez commencer à remplir des coordonnées bancaires ou des PFMPs pendant ce temps.
 - else
   .buttons-group
-    - if @etab.missing_attributive_decisions?
-      = attributive_decisions_generation_form(@etab)
-    = attributive_decisions_download_button(@etab)
+    - if current_establishment.missing_attributive_decisions?
+      = attributive_decisions_generation_form(current_establishment)
+    = attributive_decisions_download_button(current_establishment)

--- a/app/views/home/home.html.haml
+++ b/app/views/home/home.html.haml
@@ -1,7 +1,7 @@
 .home.fr-container
   .fr-grid-row.fr-grid-row--center
     .fr-col-lg-7
-      - if @etab.fetching_students
+      - if current_establishment.fetching_students
         = dsfr_alert(type: :info, title: "Récupération des élèves en cours") do
           %p Nous sommes en train de récupérer les données de vos élèves, veuillez rafraichir la page dans quelques minutes.
       - else

--- a/app/views/invitations/index.html.haml
+++ b/app/views/invitations/index.html.haml
@@ -8,7 +8,7 @@
       éditer les décisions d'attribution, valider les PFMPs 
       pour les envoyer en paiement et gérer la liste des accès.
 
-    = link_to "Autoriser un nouvel email", new_establishment_invitation_path(@etab), class: 'fr-btn fr-btn--primary'
+    = link_to "Autoriser un nouvel email", new_establishment_invitation_path(current_establishment), class: 'fr-btn fr-btn--primary'
 
     - if @invitations.any?
       .fr-table
@@ -19,4 +19,4 @@
                 %td= invite.email
                 %td
                   .fr-grid-row.fr-grid-row--right
-                    = button_to "Retirer l'accès", establishment_invitation_path(@etab, invite), method: :delete, class: "fr-btn fr-btn--danger"
+                    = button_to "Retirer l'accès", establishment_invitation_path(current_establishment, invite), method: :delete, class: "fr-btn fr-btn--danger"

--- a/app/views/invitations/new.html.haml
+++ b/app/views/invitations/new.html.haml
@@ -1,4 +1,4 @@
-= form_with model: [@etab, @invitation], builder: DsfrFormBuilder do |form|
+= form_with model: [current_establishment, @invitation], builder: DsfrFormBuilder do |form|
   = form.dsfr_error_summary
 
   .fr-col-md-6

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -23,7 +23,7 @@
     = render 'shared/analytics' if Rails.env.production?
     = render 'shared/support_banner' if @show_support_banner
     = render 'shared/header'
-    - if @etab
+    - if current_establishment
       = render 'shared/etab_banner'
     .fr-container
       %main#main.fr-pt-3w.fr-pb-6w

--- a/app/views/shared/_etab_banner.html.haml
+++ b/app/views/shared/_etab_banner.html.haml
@@ -1,6 +1,6 @@
 .etab-banner
   .fr-container
     .fr-grid-row.fr-text--sm
-      .fr-col-sm.fr-col-12= @etab
+      .fr-col-sm.fr-col-12= current_establishment
       - if current_user.establishments.many?
         = dsfr_link_to "Changer d'établissement", user_select_establishment_path(current_user), class: "fr-text--sm"

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -41,9 +41,9 @@
               %li.fr-nav__item
                 %a.fr-nav__link{ href: validations_path, target: "_self", "aria-current" => current_path_is_validation? ? "page" : nil }
                   = t("menu.validate_all_pfmps")
-            - if @etab.present? && current_user.can_invite?
+            - if current_establishment.present? && current_user.can_invite?
               %li.fr-nav__item
-                %a.fr-nav__link{ href: establishment_invitations_path(@etab), target: "_self", "aria-current" => current_path?(establishment_invitations_path(@etab)) ? "page" : nil }
+                %a.fr-nav__link{ href: establishment_invitations_path(current_establishment), target: "_self", "aria-current" => current_path?(establishment_invitations_path(current_establishment)) ? "page" : nil }
                   = t("menu.invitations")
 
             %li.fr-nav__item

--- a/spec/models/schooling_spec.rb
+++ b/spec/models/schooling_spec.rb
@@ -98,4 +98,20 @@ RSpec.describe Schooling do
       expect { schooling.reopen! }.to change(schooling, :open?).from(false).to(true)
     end
   end
+
+  describe "with_attributive_decisions" do
+    subject { described_class.with_attributive_decisions }
+
+    let(:schooling) { create(:schooling) }
+
+    context "when the schooling does not have an attached attributive decision" do
+      it { is_expected.not_to include(schooling) }
+    end
+
+    context "when the schooling has an attached attributive decision" do
+      let(:schooling) { create(:schooling, :with_attributive_decision) }
+
+      it { is_expected.to include(schooling) }
+    end
+  end
 end


### PR DESCRIPTION
Conventional wisdom frowns upon instance variables, not just in Rails but in the OOP programming world: you should use accessors instead, even if they just point to the thing.

Do exactly that by exposing a `current_establishment` helper that accesses the @current_establishment variable but doesn't expose it to the rest of the world.

Last but not least: I profoundly regretted using the very-French @etab abbreviation so that is now fixed.