### PR TITLE
asp: use the exact ASP entities name

### DIFF
--- a/app/services/asp/entities/adresse.rb
+++ b/app/services/asp/entities/adresse.rb
@@ -20,18 +20,16 @@ module ASP
       validates :codepostalcedex, :codecominsee, presence: true, if: :french_address?
       validates :bureaudistribetranger, :localiteetranger, presence: true, if: :foreign_address?
 
-      def fragment(builder)
-        builder.adresse do |xml|
-          xml.codetypeadr(codetypeadr)
-          xml.codeinseepays(codeinseepays)
+      def fragment(xml)
+        xml.codetypeadr(codetypeadr)
+        xml.codeinseepays(codeinseepays)
 
-          if french_address?
-            xml.codepostalcedex(codepostalcedex)
-            xml.codecominsee(codecominsee)
-          else
-            xml.localiteetranger(localiteetranger)
-            xml.bureaudistribetranger(bureaudistribetranger)
-          end
+        if french_address?
+          xml.codepostalcedex(codepostalcedex)
+          xml.codecominsee(codecominsee)
+        else
+          xml.localiteetranger(localiteetranger)
+          xml.bureaudistribetranger(bureaudistribetranger)
         end
       end
 

--- a/app/services/asp/entities/coord_paie.rb
+++ b/app/services/asp/entities/coord_paie.rb
@@ -2,7 +2,7 @@
 
 module ASP
   module Entities
-    class CoordonneesPaiement < Entity
+    class CoordPaie < Entity
       CODE_MODE_REGLEMENT_IBAN = "135"
       CODE_TYPE_COORDONNEE_PAIEMENT_PRINCIPALE = "PRINCIPALE"
 
@@ -22,14 +22,12 @@ module ASP
                                clecontrole
                                bic]
 
-      def fragment(builder)
-        builder.coordpaie do |xml|
-          xml.codetypecoordpaie(codetypecoordpaie)
-          xml.codemodereglement(codemodereglement)
-          xml.intitdest(intitdest)
+      def fragment(xml)
+        xml.codetypecoordpaie(codetypecoordpaie)
+        xml.codemodereglement(codemodereglement)
+        xml.intitdest(intitdest)
 
-          iban(xml)
-        end
+        iban(xml)
       end
 
       private

--- a/app/services/asp/entities/dossier.rb
+++ b/app/services/asp/entities/dossier.rb
@@ -11,12 +11,10 @@ module ASP
 
       validates :numadm, presence: true
 
-      def fragment(builder)
-        builder.dossier do |xml|
-          xml.numadm(numadm)
-          xml.listeprestadoss do
-            PrestationDossier.from_payment(payment).to_xml(xml)
-          end
+      def fragment(xml)
+        xml.numadm(numadm)
+        xml.listeprestadoss do
+          Prestadoss.from_payment(payment).to_xml(xml)
         end
       end
     end

--- a/app/services/asp/entities/enregistrement.rb
+++ b/app/services/asp/entities/enregistrement.rb
@@ -11,18 +11,16 @@ module ASP
 
       validates_presence_of :id_enregistrement
 
-      def fragment(builder)
-        builder.enregistrement(idEnregistrement: id_enregistrement) do |xml|
-          individu(xml)
-        end
+      def xml_root_args
+        { idEnregistrement: id_enregistrement }
       end
 
-      def individu(xml)
+      def fragment(xml)
         xml.individu do
           xml.natureindividu("P")
-          PersonnePhysique.from_payment(payment).to_xml(xml)
+          PersPhysique.from_payment(payment).to_xml(xml)
           xml.adressesindividu { Adresse.from_payment(payment).to_xml(xml) }
-          xml.coordpaiesindividu { CoordonneesPaiement.from_payment(payment).to_xml(xml) }
+          xml.coordpaiesindividu { CoordPaie.from_payment(payment).to_xml(xml) }
           xml.listedossier { Dossier.from_payment(payment).to_xml(xml) }
         end
       end

--- a/app/services/asp/entities/entity.rb
+++ b/app/services/asp/entities/entity.rb
@@ -33,14 +33,21 @@ module ASP
         end
       end
 
-      def to_xml(builder)
-        validate!
-
-        builder.tap { |xml| fragment(xml) }
+      def xml_root_args
+        {}
       end
 
-      def fragment(builder)
-        raise NotImplementedError
+      def to_xml(builder)
+        root_node = self.class.name.demodulize.downcase
+        args = xml_root_args
+
+        validate!
+
+        builder.tap do |xml|
+          xml.send(root_node, args) do |x|
+            fragment(x)
+          end
+        end
       end
     end
   end

--- a/app/services/asp/entities/pers_physique.rb
+++ b/app/services/asp/entities/pers_physique.rb
@@ -2,7 +2,7 @@
 
 module ASP
   module Entities
-    class PersonnePhysique < Entity
+    class PersPhysique < Entity
       attribute :titre, :string
       attribute :nomusage, :string
       attribute :nomnaissance, :string
@@ -22,16 +22,14 @@ module ASP
 
       validates_presence_of :codeinseecommune, if: :born_in_france?
 
-      def fragment(builder)
-        builder.persphysique do |xml|
-          xml.titre(titre)
-          xml.prenom(prenom)
-          xml.nomusage(nomusage)
-          xml.nomnaissance(nomnaissance)
-          xml.datenaissance(I18n.l(datenaissance, format: :asp))
-          xml.codeinseepaysnai(codeinseepaysnai)
-          xml.codeinseecommune(codeinseecommune)
-        end
+      def fragment(xml)
+        xml.titre(titre)
+        xml.prenom(prenom)
+        xml.nomusage(nomusage)
+        xml.nomnaissance(nomnaissance)
+        xml.datenaissance(I18n.l(datenaissance, format: :asp))
+        xml.codeinseepaysnai(codeinseepaysnai)
+        xml.codeinseecommune(codeinseecommune)
       end
 
       private

--- a/app/services/asp/entities/prestadoss.rb
+++ b/app/services/asp/entities/prestadoss.rb
@@ -4,7 +4,7 @@ require "asp/constants"
 
 module ASP
   module Entities
-    class PrestationDossier < Entity
+    class Prestadoss < Entity
       include ASP::Constants
 
       attribute :numadm, :string
@@ -15,17 +15,15 @@ module ASP
 
       validates_presence_of %i[numadm datecomplete datereceptionprestadoss montanttotalengage valeur]
 
-      def fragment(builder)
-        builder.prestadoss do |xml|
-          xml.numadm(numadm)
-          xml.codeprestadispo(CODE_DISPOSITIF)
-          xml.datecompletude(datecomplete)
-          xml.datereceptionprestadoss(datereceptionprestadoss)
-          xml.montanttotalengage(montanttotalengage)
-          xml.code("D")
-          xml.valeur(valeur)
-          xml.indicrattachusprestadispo("O")
-        end
+      def fragment(xml)
+        xml.numadm(numadm)
+        xml.codeprestadispo(CODE_DISPOSITIF)
+        xml.datecompletude(datecomplete)
+        xml.datereceptionprestadoss(datereceptionprestadoss)
+        xml.montanttotalengage(montanttotalengage)
+        xml.code("D")
+        xml.valeur(valeur)
+        xml.indicrattachusprestadispo("O")
       end
     end
   end

--- a/app/services/asp/mappers/coord_paie_mapper.rb
+++ b/app/services/asp/mappers/coord_paie_mapper.rb
@@ -2,7 +2,7 @@
 
 module ASP
   module Mappers
-    class CoordonneesPaiementMapper
+    class CoordPaieMapper
       PRINCIPAL_ADDRESS_TYPE = "PRINCIPALE"
 
       MAPPING = {

--- a/app/services/asp/mappers/pers_physique_mapper.rb
+++ b/app/services/asp/mappers/pers_physique_mapper.rb
@@ -2,7 +2,7 @@
 
 module ASP
   module Mappers
-    class PersonnePhysiqueMapper
+    class PersPhysiqueMapper
       MAPPING = {
         prenom: :first_name,
         nomusage: :last_name,

--- a/app/services/asp/mappers/prestadoss_mapper.rb
+++ b/app/services/asp/mappers/prestadoss_mapper.rb
@@ -2,7 +2,7 @@
 
 module ASP
   module Mappers
-    class PrestationDossierMapper
+    class PrestadossMapper
       MAPPING = {
         numadm: :attributive_decision_number
       }.freeze

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -103,7 +103,7 @@ RSpec.configure do |config|
       klass = "ASP::Entities::#{name}".constantize
       double = instance_double(name)
 
-      allow(double).to receive(:to_xml) { |builder| builder.send(name) }
+      allow(double).to receive(:to_xml) { |builder| builder.send(name.downcase) }
       allow(klass).to receive(:from_payment).and_return(double)
     end
   end

--- a/spec/services/asp/entities/coord_paie_spec.rb
+++ b/spec/services/asp/entities/coord_paie_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe ASP::Entities::CoordonneesPaiement, type: :model do
+describe ASP::Entities::CoordPaie, type: :model do
   let(:student) { create(:student, :with_rib) }
   let(:payment) { create(:payment) }
 

--- a/spec/services/asp/entities/dossier_spec.rb
+++ b/spec/services/asp/entities/dossier_spec.rb
@@ -7,7 +7,7 @@ describe ASP::Entities::Dossier, type: :model do
   let(:schooling) { payment.pfmp.schooling }
 
   before do
-    mock_entity("PrestationDossier")
+    mock_entity("Prestadoss")
   end
 
   it_behaves_like "an ASP payment mapping entity"

--- a/spec/services/asp/entities/enregistrement_spec.rb
+++ b/spec/services/asp/entities/enregistrement_spec.rb
@@ -6,7 +6,7 @@ describe ASP::Entities::Enregistrement, type: :model do
   let(:payment) { create(:payment) }
 
   before do
-    %w[PersonnePhysique Adresse CoordonneesPaiement Dossier].each { |name| mock_entity(name) }
+    %w[PersPhysique Adresse CoordPaie Dossier].each { |name| mock_entity(name) }
   end
 
   it_behaves_like "an ASP payment mapping entity"

--- a/spec/services/asp/entities/entities_integration_spec.rb
+++ b/spec/services/asp/entities/entities_integration_spec.rb
@@ -24,6 +24,8 @@ describe "ASP Entities" do # rubocop:disable RSpec/DescribeClass
   end
 
   it "produce valid documents" do
-    expect { file.validate! }.not_to raise_error
+    log_on_failure = -> { file.errors.each { |e| puts "ASP validation error: #{e.message}\n" } }
+
+    expect { file.validate! }.not_to raise_error, log_on_failure
   end
 end

--- a/spec/services/asp/entities/pers_physique_spec.rb
+++ b/spec/services/asp/entities/pers_physique_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe ASP::Entities::PersonnePhysique, type: :model do
+describe ASP::Entities::PersPhysique, type: :model do
   let(:student) { create(:student, :female, :with_address_info, :with_birthplace_info, first_name: "Marie") }
   let(:payment) { create(:payment) }
 

--- a/spec/services/asp/entities/prestadoss_spec.rb
+++ b/spec/services/asp/entities/prestadoss_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe ASP::Entities::PrestationDossier, type: :model do
+describe ASP::Entities::Prestadoss, type: :model do
   let(:payment) { create(:payment) }
   let(:schooling) { payment.pfmp.schooling }
 

--- a/spec/services/asp/mappers/coord_paie_mapper_spec.rb
+++ b/spec/services/asp/mappers/coord_paie_mapper_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe ASP::Mappers::CoordonneesPaiementMapper do
+describe ASP::Mappers::CoordPaieMapper do
   subject(:mapper) { described_class.new(payment) }
 
   let(:payment) { create(:payment) }

--- a/spec/services/asp/mappers/pers_physique_mapper_spec.rb
+++ b/spec/services/asp/mappers/pers_physique_mapper_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-describe ASP::Mappers::PersonnePhysiqueMapper do
+describe ASP::Mappers::PersPhysiqueMapper do
   subject(:mapper) { described_class.new(payment) }
 
   let(:payment) { create(:payment) }


### PR DESCRIPTION
Removing the tiny layer of abstraction between our class name (PersonnePhysique) and the actual ASP name (PersPhysique) means less logic and being able to infer the root node automatically which greatly simplifies the XML fragment code. As much as I dislike the abbreviated French names it's still simpler than introducing that extra layer of French-but-correctly-spelled-out-names.