### PR TITLE
classes: fix nb_attributive_decisions_per_class

### DIFF
--- a/app/models/concerns/classes_indicators.rb
+++ b/app/models/concerns/classes_indicators.rb
@@ -10,7 +10,7 @@ module ClassesIndicators
 
   def nb_attributive_decisions_per_class(classes)
     classes.joins(:active_schoolings)
-           .with_attributive_decisions
+           .merge(Schooling.with_attributive_decisions)
            .group(:"classes.id")
            .count
   end


### PR DESCRIPTION
On utilisait le `with_attributive_decisions` de classe, qui refaisait une jointure de schooling supplémentaire, multipliant ainsi le nombre de DA comptées.