### PR TITLE
rib: ensure we cannot have multiple active ribs per student

### DIFF
--- a/app/models/rib.rb
+++ b/app/models/rib.rb
@@ -4,12 +4,19 @@ class Rib < ApplicationRecord
   belongs_to :student
 
   validates :iban, :bic, :name, presence: true
+  validates :student_id, uniqueness: { scope: :archived_at }, if: :active?
 
   # courtesy of gem 'bank-account'
   validates :iban, iban: true
   validates :bic, bic: true
 
-  def safe_iban
-    iban.chars.fill("X", 4).join
+  scope :active, -> { where.not(archived_at: nil) }
+
+  def active?
+    archived_at.blank?
+  end
+
+  def inactive?
+    !active?
   end
 end

--- a/db/migrate/20240123163436_add_database_constraints_on_ribs.rb
+++ b/db/migrate/20240123163436_add_database_constraints_on_ribs.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDatabaseConstraintsOnRibs < ActiveRecord::Migration[7.1]
+  def change
+    add_index :ribs, :student_id, name: :one_active_rib_per_student, unique: true, where: "archived_at is null"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_17_162049) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_23_163436) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -163,6 +163,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_17_162049) do
     t.string "name", null: false
     t.boolean "personal", default: false, null: false
     t.index ["student_id"], name: "index_ribs_on_student_id"
+    t.index ["student_id"], name: "one_active_rib_per_student", unique: true, where: "(archived_at IS NULL)"
   end
 
   create_table "schoolings", force: :cascade do |t|

--- a/spec/models/rib_spec.rb
+++ b/spec/models/rib_spec.rb
@@ -13,5 +13,7 @@ RSpec.describe Rib do
     it { is_expected.to validate_presence_of(:iban) }
     it { is_expected.to validate_presence_of(:bic) }
     it { is_expected.to validate_presence_of(:name) }
+
+    it { is_expected.to validate_uniqueness_of(:student_id).scoped_to(:archived_at) }
   end
 end


### PR DESCRIPTION
For some reason this was missed in the earlier migration. Ensure we cannot have multiple active ribs for one student, which can happen if someone has bad network and submits many times in a row (which seems common).