### PR TITLE
config: tune down the Sentry sample rate

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -7,11 +7,7 @@ Sentry.init do |config|
   # Set traces_sample_rate to 1.0 to capture 100%
   # of transactions for performance monitoring.
   # We recommend adjusting this value in production.
-  config.traces_sample_rate = 1.0
-  # or
-  config.traces_sampler = lambda do |_context|
-    true
-  end
+  config.traces_sample_rate = 0.1
 
   config.include_local_variables = true
 


### PR DESCRIPTION
We were using the default Sentry sample rate which sends every transaction and error across the wire. It's just an example and they actually recommend adjusting the setting to balance between performance and signal.

Tune down to 10% as this should still get us significant data and reduce the overhead.

Suggested-by: Julien Bouquillon <julien.bouquillon@beta.gouv.fr>