### PR TITLE
sentry: name the breadcrumbs data more precisely

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -20,11 +20,11 @@ module Users
 
       @user.save!
 
-      add_auth_breadcrumb(data: @user.id, message: "Successfully parsed user")
+      add_auth_breadcrumb(data: { user_id: @user.id }, message: "Successfully parsed user")
 
       check_access!
 
-      add_auth_breadcrumb(data: @mapper.all_indicated_uais, message: "Found establishments")
+      add_auth_breadcrumb(data: { user_uais: @mapper.all_indicated_uais }, message: "Found establishments")
 
       log_user_in!
       save_roles!


### PR DESCRIPTION
Otherwise it's just scraped, which is not helpful or rightful here.