### PR TITLE
stats: compute stats from production with reusable classes

### DIFF
--- a/app/models/pfmp.rb
+++ b/app/models/pfmp.rb
@@ -20,6 +20,8 @@ class Pfmp < ApplicationRecord
 
   validates :day_count, numericality: { only_integer: true, allow_nil: true, greater_than: 0 }
 
+  scope :finished, -> { where("pfmps.end_date <= (?)", Time.zone.today) }
+
   include Statesman::Adapters::ActiveRecordQueries[
     transition_class: PfmpTransition,
     initial_state: PfmpStateMachine.initial_state,

--- a/app/models/stats/base.rb
+++ b/app/models/stats/base.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+module Stats
+  class Base
+    def title
+      raise NotImplementedError
+    end
+
+    def with_mef_and_establishment
+      raise NotImplementedError
+    end
+
+    def with_establishment
+      raise NotImplementedError
+    end
+
+    def global_data
+      raise NotImplementedError
+    end
+
+    def bops_data
+      raise NotImplementedError
+    end
+
+    def menj_academies_data
+      raise NotImplementedError
+    end
+
+    def establishments_data
+      raise NotImplementedError
+    end
+
+    def bop
+      Arel.sql(
+        %(
+          CASE mefs.ministry
+          WHEN 0 THEN (CASE private_contract_type_code WHEN '99' THEN 'ENPU' ELSE 'ENPR' END)
+          ELSE mefs.ministry::text END
+        )
+      )
+    end
+
+    def bop_key_map(bop)
+      %w[ENPU ENPR].include?(bop) ? bop : Mef.ministries.invert[bop.to_i].upcase
+    end
+
+    def group_per_bop(collection)
+      collection.merge(with_mef_and_establishment)
+                .group(bop)
+    end
+
+    def group_per_menj_academy(collection)
+      collection.merge(with_mef_and_establishment)
+                .where("mefs.ministry": :menj)
+                .order(:academy_label)
+                .group(:academy_label)
+    end
+
+    def group_per_establishment(collection)
+      collection.merge(with_establishment)
+                .order(:uai)
+                .group(:uai)
+    end
+  end
+end

--- a/app/models/stats/count.rb
+++ b/app/models/stats/count.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Stats
+  class Count < Base
+    attr_reader :all
+
+    def initialize(all: 0)
+      @all = all
+      super()
+    end
+
+    def global_data
+      all.count
+    end
+
+    def bops_data
+      @bops_data ||= group_per_bop(all).count.transform_keys { |bop| bop_key_map(bop) }
+    end
+
+    def menj_academies_data
+      @menj_academies_data ||= group_per_menj_academy(all).count
+    end
+
+    def establishments_data
+      @establishments_data ||= group_per_establishment(all).count
+    end
+  end
+end

--- a/app/models/stats/indicator/attributive_decisions.rb
+++ b/app/models/stats/indicator/attributive_decisions.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Stats
+  module Indicator
+    class AttributiveDecisions < Ratio
+      def initialize
+        super(
+          subset: Schooling.with_attributive_decisions,
+          all: Schooling.all
+        )
+      end
+
+      def title
+        "Décisions d'attributions éditées"
+      end
+
+      def with_mef_and_establishment
+        Schooling.joins(classe: %i[mef establishment])
+      end
+
+      def with_establishment
+        Schooling.joins(classe: :establishment)
+      end
+    end
+  end
+end

--- a/app/models/stats/indicator/payments.rb
+++ b/app/models/stats/indicator/payments.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Stats
+  module Indicator
+    class Payments < Sum
+      def initialize
+        super(
+          column: :amount,
+          all: Payment.joins(pfmp: { schooling: { student: :rib } })
+                      .merge(Pfmp.finished)
+                      .merge(Pfmp.in_state(:validated))
+                      .merge(Schooling.with_attributive_decisions)
+                      .merge(Student.asp_ready)
+        )
+      end
+
+      def title
+        "Somme des PFMPs terminées validées avec RIB, DA & données élèves"
+      end
+
+      def with_mef_and_establishment
+        Payment.joins(schooling: { classe: %i[mef establishment] })
+      end
+
+      def with_establishment
+        Payment.joins(schooling: { classe: :establishment })
+      end
+    end
+  end
+end

--- a/app/models/stats/indicator/pfmps.rb
+++ b/app/models/stats/indicator/pfmps.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Stats
+  module Indicator
+    class Pfmps < Count
+      def initialize
+        super(
+          all: Pfmp.all
+        )
+      end
+
+      def title
+        "Toutes les PFMPs (même non complétées)"
+      end
+
+      def with_mef_and_establishment
+        Pfmp.joins(schooling: { classe: %i[mef establishment] })
+      end
+
+      def with_establishment
+        Pfmp.joins(schooling: { classe: :establishment })
+      end
+    end
+  end
+end

--- a/app/models/stats/indicator/ribs.rb
+++ b/app/models/stats/indicator/ribs.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Stats
+  module Indicator
+    class Ribs < Ratio
+      def initialize
+        super(
+          subset: Student.joins(:rib),
+          all: Student.all
+        )
+      end
+
+      def title
+        "Coordonnées bancaires saisies"
+      end
+
+      def with_mef_and_establishment
+        Student.joins(schoolings: { classe: %i[mef establishment] })
+      end
+
+      def with_establishment
+        Student.joins(schoolings: { classe: :establishment })
+      end
+    end
+  end
+end

--- a/app/models/stats/indicator/schoolings.rb
+++ b/app/models/stats/indicator/schoolings.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Stats
+  module Indicator
+    class Schoolings < Count
+      def initialize
+        super(
+          all: Schooling.all
+        )
+      end
+
+      def title
+        "Scolarités concernées"
+      end
+
+      def with_mef_and_establishment
+        Schooling.joins(classe: %i[mef establishment])
+      end
+
+      def with_establishment
+        Schooling.joins(classe: :establishment)
+      end
+    end
+  end
+end

--- a/app/models/stats/indicator/students_data.rb
+++ b/app/models/stats/indicator/students_data.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Stats
+  module Indicator
+    class StudentsData < Ratio
+      def initialize
+        super(
+          subset: Student.asp_ready,
+          all: Student.all
+        )
+      end
+
+      def title
+        "Données d'élèves nécessaires présentes"
+      end
+
+      def with_mef_and_establishment
+        Student.joins(schoolings: { classe: %i[mef establishment] })
+      end
+
+      def with_establishment
+        Student.joins(schoolings: { classe: :establishment })
+      end
+    end
+  end
+end

--- a/app/models/stats/indicator/validated_pfmps.rb
+++ b/app/models/stats/indicator/validated_pfmps.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Stats
+  module Indicator
+    class ValidatedPfmps < Ratio
+      def initialize
+        finished_pfmps = Pfmp.finished
+
+        super(
+          subset: finished_pfmps.in_state(:validated),
+          all: finished_pfmps
+        )
+      end
+
+      def title
+        "PFMPs terminées et validées"
+      end
+
+      def with_mef_and_establishment
+        Pfmp.joins(schooling: { classe: %i[mef establishment] })
+      end
+
+      def with_establishment
+        Pfmp.joins(schooling: { classe: :establishment })
+      end
+    end
+  end
+end

--- a/app/models/stats/indicator/yearly_amounts.rb
+++ b/app/models/stats/indicator/yearly_amounts.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Stats
+  module Indicator
+    class YearlyAmounts < Sum
+      def initialize
+        super(
+          column: :yearly_cap,
+          all: Schooling.joins(classe: :mef)
+                        .merge(Mef.with_wages)
+        )
+      end
+
+      def title
+        "Somme des montants annuels"
+      end
+
+      def with_mef_and_establishment
+        Schooling.joins(classe: %i[mef establishment])
+      end
+
+      def with_establishment
+        Schooling.joins(classe: :establishment)
+      end
+    end
+  end
+end

--- a/app/models/stats/ratio.rb
+++ b/app/models/stats/ratio.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Stats
+  class Ratio < Base
+    attr_reader :subset, :all
+
+    def initialize(subset: 0, all: 0)
+      @subset = subset
+      @all = all
+      super()
+    end
+
+    def global_data
+      subset.count.to_f / all.count
+    end
+
+    def bops_data
+      @bops_data ||= data_per_attribute(:group_per_bop, key_map: :bop_key_map)
+    end
+
+    def menj_academies_data
+      @menj_academies_data ||= data_per_attribute(:group_per_menj_academy)
+    end
+
+    def establishments_data
+      @establishments_data ||= data_per_attribute(:group_per_establishment)
+    end
+
+    def data_per_attribute(group_method, key_map: nil)
+      subset_counted_per_attribute = send(group_method, subset).count
+      all_counted_per_attribute = send(group_method, all).count
+
+      subset_counted_per_attribute.to_h do |attribute, subset_count|
+        all_count = all_counted_per_attribute[attribute]
+        attribute = send(key_map, attribute) if key_map.present?
+        ratio = subset_count.to_f / all_count
+        [attribute, ratio]
+      end
+    end
+  end
+end

--- a/app/models/stats/sum.rb
+++ b/app/models/stats/sum.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Stats
+  class Sum < Base
+    attr_reader :all, :column
+
+    def initialize(all: 0, column: 0)
+      @all = all
+      @column = column
+      super()
+    end
+
+    def global_data
+      all.sum(column)
+    end
+
+    def bops_data
+      @bops_data ||= group_per_bop(all).sum(column).transform_keys { |bop| bop_key_map(bop) }
+    end
+
+    def menj_academies_data
+      @menj_academies_data ||= group_per_menj_academy(all).sum(column)
+    end
+
+    def establishments_data
+      @establishments_data ||= group_per_establishment(all).sum(column)
+    end
+  end
+end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -34,6 +34,15 @@ class Student < ApplicationRecord
 
   scope :without_ribs, -> { where.missing(:rib) }
 
+  scope :asp_ready, lambda {
+    where(biological_sex: [1, 2])
+      .where.not(address_postal_code: nil)
+      .where.not(address_country_code: %w[995 990] + [nil])
+      .where.not(birthplace_country_insee_code: %w[995 990] + [nil])
+      .where.not("address_country_code IN (?) AND address_city_insee_code IS NULL", %w[100 99100])
+      .where.not("birthplace_country_insee_code IN (?) AND birthplace_city_insee_code IS NULL", %w[100 99100])
+  }
+
   before_validation :check_asp_file_reference
 
   def to_s

--- a/spec/factories/mefs.rb
+++ b/spec/factories/mefs.rb
@@ -9,7 +9,9 @@ FactoryBot.define do
     ministry { Mef.ministries[:menj] }
 
     transient do
-      wage { create(:wage) } # rubocop:disable FactoryBot/FactoryAssociationWithStrategy
+      daily_rate { 1 }
+      yearly_cap { 100 }
+      wage { create(:wage, daily_rate: daily_rate, yearly_cap: yearly_cap) } # rubocop:disable FactoryBot/FactoryAssociationWithStrategy
     end
 
     after :create do |mef, evaluator|

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -55,7 +55,9 @@ FactoryBot.define do
     end
 
     trait :with_rib do
-      rib
+      after(:create) do |student|
+        create(:rib, student: student)
+      end
     end
 
     trait :born_in_france do

--- a/spec/models/stats/indicator/attributive_decisions_spec.rb
+++ b/spec/models/stats/indicator/attributive_decisions_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "./spec/models/stats/shared_contexts"
+
+describe Stats::Indicator::AttributiveDecisions do
+  describe "#global_data" do
+    subject { described_class.new.global_data }
+
+    include_context "when there is data for global stats"
+
+    it { is_expected.to eq 0.4 }
+  end
+
+  describe "#bops_data" do
+    subject { described_class.new.bops_data }
+
+    include_context "when there is data for stats per bops"
+
+    it { is_expected.to eq({ "ENPU" => 0.25, "ENPR" => 0.8, "MASA" => 0.4, "MER" => 4.0 / 7, "ARMEE" => 0.5 }) }
+  end
+
+  describe "#menj_academies_data" do
+    subject { described_class.new.menj_academies_data }
+
+    include_context "when there is data for stats per MENJ academies"
+
+    it { is_expected.to eq({ "Bordeaux" => 0.25, "Montpellier" => 0.5, "Paris" => 0.4 }) }
+
+    context "with a non-menj mef" do
+      include_context "when there is also data for a non MENJ academy"
+      it { is_expected.to eq({ "Bordeaux" => 0.25, "Montpellier" => 0.5, "Paris" => 0.4 }) }
+    end
+  end
+
+  describe "#establishments_data" do
+    subject { described_class.new.establishments_data }
+
+    include_context "when there is data for stats per establishments"
+
+    it { is_expected.to eq({ "etab1" => 0.25, "etab2" => 0.5, "etab3" => 0.4 }) }
+  end
+end

--- a/spec/models/stats/indicator/payments_spec.rb
+++ b/spec/models/stats/indicator/payments_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "./spec/models/stats/shared_contexts"
+
+describe Stats::Indicator::Payments do
+  describe "#global_data" do
+    subject { described_class.new.global_data }
+
+    include_context "when there is data for global stats"
+
+    it { is_expected.to eq 10 }
+  end
+
+  describe "#bops_data" do
+    subject { described_class.new.bops_data }
+
+    include_context "when there is data for stats per bops"
+
+    it { is_expected.to eq({ "ENPU" => 5.0, "ENPR" => 20, "MASA" => 10.0, "MER" => 20.0, "ARMEE" => 15.0 }) }
+  end
+
+  describe "#menj_academies_data" do
+    subject { described_class.new.menj_academies_data }
+
+    include_context "when there is data for stats per MENJ academies"
+
+    it { is_expected.to eq({ "Bordeaux" => 5.0, "Montpellier" => 15.0, "Paris" => 10.0 }) }
+  end
+
+  describe "#establishments_data" do
+    subject { described_class.new.establishments_data }
+
+    include_context "when there is data for stats per establishments"
+
+    it { is_expected.to eq({ "etab1" => 5.0, "etab2" => 15.0, "etab3" => 10.0 }) }
+  end
+end

--- a/spec/models/stats/indicator/pfmps_spec.rb
+++ b/spec/models/stats/indicator/pfmps_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "./spec/models/stats/shared_contexts"
+
+describe Stats::Indicator::Pfmps do
+  describe "#global_data" do
+    subject { described_class.new.global_data }
+
+    include_context "when there is data for global stats"
+
+    it { is_expected.to eq 5 }
+  end
+
+  describe "#bops_data" do
+    subject { described_class.new.bops_data }
+
+    include_context "when there is data for stats per bops"
+
+    it { is_expected.to eq({ "ENPU" => 4, "ENPR" => 5, "MASA" => 5, "MER" => 7, "ARMEE" => 6 }) }
+  end
+
+  describe "#menj_academies_data" do
+    subject { described_class.new.menj_academies_data }
+
+    include_context "when there is data for stats per MENJ academies"
+
+    it { is_expected.to eq({ "Bordeaux" => 4, "Montpellier" => 6, "Paris" => 5 }) }
+  end
+
+  describe "#establishments_data" do
+    subject { described_class.new.establishments_data }
+
+    include_context "when there is data for stats per establishments"
+
+    it { is_expected.to eq({ "etab1" => 4, "etab2" => 6, "etab3" => 5 }) }
+  end
+end

--- a/spec/models/stats/indicator/ribs_spec.rb
+++ b/spec/models/stats/indicator/ribs_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "./spec/models/stats/shared_contexts"
+
+describe Stats::Indicator::Ribs do
+  describe "#global_data" do
+    subject { described_class.new.global_data }
+
+    include_context "when there is data for global stats"
+
+    it { is_expected.to eq 0.4 }
+  end
+
+  describe "#bops_data" do
+    subject { described_class.new.bops_data }
+
+    include_context "when there is data for stats per bops"
+
+    it { is_expected.to eq({ "ENPU" => 0.25, "ENPR" => 0.8, "MASA" => 0.4, "MER" => 4.0 / 7, "ARMEE" => 0.5 }) }
+  end
+
+  describe "#menj_academies_data" do
+    subject { described_class.new.menj_academies_data }
+
+    include_context "when there is data for stats per MENJ academies"
+
+    it { is_expected.to eq({ "Bordeaux" => 0.25, "Montpellier" => 0.5, "Paris" => 0.4 }) }
+  end
+
+  describe "#establishments_data" do
+    subject { described_class.new.establishments_data }
+
+    include_context "when there is data for stats per establishments"
+
+    it { is_expected.to eq({ "etab1" => 0.25, "etab2" => 0.5, "etab3" => 0.4 }) }
+  end
+end

--- a/spec/models/stats/indicator/schoolings_spec.rb
+++ b/spec/models/stats/indicator/schoolings_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "./spec/models/stats/shared_contexts"
+
+describe Stats::Indicator::Schoolings do
+  describe "#global_data" do
+    subject { described_class.new.global_data }
+
+    include_context "when there is data for global stats"
+
+    it { is_expected.to eq 5 }
+  end
+
+  describe "#bops_data" do
+    subject { described_class.new.bops_data }
+
+    include_context "when there is data for stats per bops"
+
+    it { is_expected.to eq({ "ENPU" => 4, "ENPR" => 5, "MASA" => 5, "MER" => 7, "ARMEE" => 6 }) }
+  end
+
+  describe "#menj_academies_data" do
+    subject { described_class.new.menj_academies_data }
+
+    include_context "when there is data for stats per MENJ academies"
+
+    it { is_expected.to eq({ "Bordeaux" => 4, "Montpellier" => 6, "Paris" => 5 }) }
+  end
+
+  describe "#establishments_data" do
+    subject { described_class.new.establishments_data }
+
+    include_context "when there is data for stats per establishments"
+
+    it { is_expected.to eq({ "etab1" => 4, "etab2" => 6, "etab3" => 5 }) }
+  end
+end

--- a/spec/models/stats/indicator/students_data_spec.rb
+++ b/spec/models/stats/indicator/students_data_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "./spec/models/stats/shared_contexts"
+
+describe Stats::Indicator::StudentsData do
+  describe "#global_data" do
+    subject { described_class.new.global_data }
+
+    include_context "when there is data for global stats"
+
+    it { is_expected.to eq 0.4 }
+  end
+
+  describe "#bops_data" do
+    subject { described_class.new.bops_data }
+
+    include_context "when there is data for stats per bops"
+
+    it { is_expected.to eq({ "ENPU" => 0.25, "ENPR" => 0.8, "MASA" => 0.4, "MER" => 4.0 / 7, "ARMEE" => 0.5 }) }
+  end
+
+  describe "#menj_academies_data" do
+    subject { described_class.new.menj_academies_data }
+
+    include_context "when there is data for stats per MENJ academies"
+
+    it { is_expected.to eq({ "Bordeaux" => 0.25, "Montpellier" => 0.5, "Paris" => 0.4 }) }
+  end
+
+  describe "#establishments_data" do
+    subject { described_class.new.establishments_data }
+
+    include_context "when there is data for stats per establishments"
+
+    it { is_expected.to eq({ "etab1" => 0.25, "etab2" => 0.5, "etab3" => 0.4 }) }
+  end
+end

--- a/spec/models/stats/indicator/validated_pfmps_spec.rb
+++ b/spec/models/stats/indicator/validated_pfmps_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "./spec/models/stats/shared_contexts"
+
+describe Stats::Indicator::ValidatedPfmps do
+  describe "#global_data" do
+    subject { described_class.new.global_data }
+
+    include_context "when there is data for global stats"
+
+    it { is_expected.to eq 0.4 }
+  end
+
+  describe "#bops_data" do
+    subject { described_class.new.bops_data }
+
+    include_context "when there is data for stats per bops"
+
+    it { is_expected.to eq({ "ENPU" => 0.25, "ENPR" => 0.8, "MASA" => 0.4, "MER" => 4.0 / 7, "ARMEE" => 0.5 }) }
+  end
+
+  describe "#menj_academies_data" do
+    subject { described_class.new.menj_academies_data }
+
+    include_context "when there is data for stats per MENJ academies"
+
+    it { is_expected.to eq({ "Bordeaux" => 0.25, "Montpellier" => 0.5, "Paris" => 0.4 }) }
+  end
+
+  describe "#establishments_data" do
+    subject { described_class.new.establishments_data }
+
+    include_context "when there is data for stats per establishments"
+
+    it { is_expected.to eq({ "etab1" => 0.25, "etab2" => 0.5, "etab3" => 0.4 }) }
+  end
+end

--- a/spec/models/stats/indicator/yearly_amounts_spec.rb
+++ b/spec/models/stats/indicator/yearly_amounts_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "./spec/models/stats/shared_contexts"
+
+describe Stats::Indicator::YearlyAmounts do
+  describe "#global_data" do
+    subject { described_class.new.global_data }
+
+    include_context "when there is data for global stats"
+
+    it { is_expected.to eq 500 }
+  end
+
+  describe "#bops_data" do
+    subject { described_class.new.bops_data }
+
+    include_context "when there is data for stats per bops"
+
+    it { is_expected.to eq({ "ENPU" => 400, "ENPR" => 500, "MASA" => 500, "MER" => 700, "ARMEE" => 600 }) }
+  end
+
+  describe "#menj_academies_data" do
+    subject { described_class.new.menj_academies_data }
+
+    include_context "when there is data for stats per MENJ academies"
+
+    it { is_expected.to eq({ "Bordeaux" => 400, "Montpellier" => 600, "Paris" => 500 }) }
+  end
+
+  describe "#establishments_data" do
+    subject { described_class.new.establishments_data }
+
+    include_context "when there is data for stats per establishments"
+
+    it { is_expected.to eq({ "etab1" => 400, "etab2" => 600, "etab3" => 500 }) }
+  end
+end

--- a/spec/models/stats/main_spec.rb
+++ b/spec/models/stats/main_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "./spec/models/stats/shared_contexts"
+
+RSpec.describe Stats::Main do
+  let(:indicators_titles) { described_class.new.indicators_titles }
+
+  describe "#global_data" do
+    subject(:data) { described_class.new.global_data }
+
+    include_context "when there is data for global stats"
+
+    it "computes the right percentages" do
+      expect(data).to eq(
+        [indicators_titles,
+         [0.4, 0.4, 0.4, 0.4, 10.0, 500, 5, 5]]
+      )
+    end
+  end
+
+  describe "#bops_data" do
+    subject(:data) { described_class.new.bops_data }
+
+    include_context "when there is data for stats per bops"
+
+    # rubocop:disable RSpec/ExampleLength
+    it "computes the correct percentages" do
+      expect(data).to eq(
+        [["BOP", *indicators_titles],
+         ["ENPU", 0.25, 0.25, 0.25, 0.25, 5.0, 400, 4, 4],
+         ["ENPR", 0.8, 0.8, 0.8, 0.8, 20.0, 500, 5, 5],
+         ["MASA", 0.4, 0.4, 0.4, 0.4, 10.0, 500, 5, 5],
+         ["MER", 4.0 / 7, 4.0 / 7, 4.0 / 7, 4.0 / 7, 20.0, 700, 7, 7],
+         ["ARMEE", 0.5, 0.5, 0.5, 0.5, 15.0, 600, 6, 6]]
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe "#menj_academies_data" do
+    subject(:data) { described_class.new.menj_academies_data }
+
+    include_context "when there is data for stats per MENJ academies"
+
+    # rubocop:disable RSpec/ExampleLength
+    it "computes the correct percentages" do
+      expect(data).to eq(
+        [["Académie", *indicators_titles],
+         ["Bordeaux", 0.25, 0.25, 0.25, 0.25, 5.0, 400, 4, 4],
+         ["Montpellier", 0.5, 0.5, 0.5, 0.5, 15.0, 600, 6, 6],
+         ["Paris", 0.4, 0.4, 0.4, 0.4, 10.0, 500, 5, 5]]
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe "#establishments_data" do
+    subject(:data) { described_class.new.establishments_data }
+
+    include_context "when there is data for stats per establishments"
+
+    # rubocop:disable RSpec/ExampleLength
+    # rubocop:disable Layout/LineLength
+    it "computes the correct percentages" do
+      expect(data).to eq(
+        [["UAI", "Nom de l'établissement", "Ministère", "Académie", "Privé/Public", *indicators_titles],
+         ["etab1", "etab1", "MINISTERE DE L'EDUCATION NATIONALE", "Marseille", "Public", 0.25, 0.25, 0.25, 0.25, 5.0, 400, 4, 4],
+         ["etab2", "etab2", "MINISTERE DE L'EDUCATION NATIONALE", "Marseille", "Public", 0.5, 0.5, 0.5, 0.5, 15.0, 600, 6, 6],
+         ["etab3", "etab3", "MINISTERE DE L'EDUCATION NATIONALE", "Marseille", "Public", 0.4, 0.4, 0.4, 0.4, 10.0, 500, 5, 5]]
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
+    # rubocop:enable Layout/LineLength
+  end
+
+  describe "#csv_of" do
+    subject(:csv_string) { described_class.new.csv_of(data) }
+
+    let(:data) do
+      [
+        %w[title1 title2 title3],
+        [0.999999, nil, 0.1],
+        [4.0 / 7, 0.0 / 0, 1.0 / 0]
+      ]
+    end
+
+    it "formats the data into a csv string" do
+      expect(csv_string).to eq("title1;title2;title3\n0,999999;0;0,1\n0,5714285714285714;0;Infini")
+    end
+  end
+end

--- a/spec/models/stats/shared_contexts.rb
+++ b/spec/models/stats/shared_contexts.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.shared_context "when there is data for global stats" do
+  before do
+    mef = create(:mef, daily_rate: 1, yearly_cap: 100)
+    classe = create(:classe, mef: mef)
+
+    create_list(:schooling, 3, classe: classe) do |schooling|
+      create(:pfmp, schooling: schooling, day_count: 5)
+    end
+
+    create_list(:student, 2, :with_extra_info) do |student|
+      schooling = create(:schooling, :with_attributive_decision, classe: classe, student: student)
+      create(:rib, student: student)
+      create(:pfmp, :validated, schooling: schooling, day_count: 5)
+    end
+  end
+end
+
+RSpec.shared_context "when there is data for stats per bops" do
+  before do
+    Mef.ministries.each_key.with_index do |ministry, index|
+      mef = create(:mef, ministry: ministry, daily_rate: 1, yearly_cap: 100)
+      classe = create(:classe, mef: mef)
+
+      create_list(:schooling, 3, classe: classe) do |schooling|
+        create(:pfmp, schooling: schooling, day_count: 5)
+      end
+
+      create_list(:student, index + 1, :with_extra_info) do |student|
+        schooling = create(:schooling, :with_attributive_decision, classe: classe, student: student)
+        create(:rib, student: student)
+        create(:pfmp, :validated, schooling: schooling, day_count: 5)
+      end
+    end
+
+    private_establishment = create(:establishment, :private)
+    menj_mef = create(:mef, ministry: :menj, daily_rate: 1, yearly_cap: 100)
+    private_classe = create(:classe, establishment: private_establishment, mef: menj_mef)
+
+    create_list(:schooling, 1, classe: private_classe) do |schooling|
+      create(:pfmp, schooling: schooling, day_count: 5)
+    end
+
+    create_list(:student, 4, :with_extra_info) do |student|
+      schooling = create(:schooling, :with_attributive_decision, classe: private_classe, student: student)
+      create(:rib, student: student)
+      create(:pfmp, :validated, schooling: schooling, day_count: 5)
+    end
+  end
+end
+
+RSpec.shared_context "when there is data for stats per MENJ academies" do
+  before do
+    mef = create(:mef, ministry: :menj, daily_rate: 1, yearly_cap: 100)
+
+    %w[Bordeaux Paris Montpellier].each.with_index do |academy_label, index|
+      establishment = create(:establishment, academy_label: academy_label)
+      classe = create(:classe, mef: mef, establishment: establishment)
+
+      create_list(:schooling, 3, classe: classe) do |schooling|
+        create(:pfmp, schooling: schooling, day_count: 5)
+      end
+
+      create_list(:student, index + 1, :with_extra_info) do |student|
+        schooling = create(:schooling, :with_attributive_decision, classe: classe, student: student)
+        create(:rib, student: student)
+        create(:pfmp, :validated, schooling: schooling, day_count: 5)
+      end
+    end
+  end
+end
+
+RSpec.shared_context "when there is also data for a non MENJ academy" do
+  before do
+    masa_mef = create(:mef, ministry: :masa)
+    establishment = create(:establishment, academy_label: "Bordeaux")
+    classe = create(:classe, mef: masa_mef, establishment: establishment)
+    create_list(:schooling, 3, classe: classe)
+    create_list(:schooling, 1, :with_attributive_decision, classe: classe)
+  end
+end
+
+RSpec.shared_context "when there is data for stats per establishments" do
+  before do
+    %w[etab1 etab3 etab2].each.with_index do |uai, index|
+      establishment = create(:establishment, uai: uai, name: uai)
+      mef = create(:mef, daily_rate: 1, yearly_cap: 100)
+      classe = create(:classe, establishment: establishment, mef: mef)
+
+      create_list(:schooling, 3, classe: classe) do |schooling|
+        create(:pfmp, schooling: schooling, day_count: 5)
+      end
+
+      create_list(:student, index + 1, :with_extra_info) do |student|
+        schooling = create(:schooling, :with_attributive_decision, classe: classe, student: student)
+        create(:rib, student: student)
+        create(:pfmp, :validated, schooling: schooling, day_count: 5)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/betagouv/aplypro/issues/432

Cette PR viens après la PR de gestion des scolarités fermées par ce qu'autrement les stats ne seront pas cohérentes avec les indicateurs présents dans l'appli, qui pour le moment ne prennent pas en compte les scolarités fermées.