### PR TITLE
gem: use a patched version of Zipline to fix our upgrade to Puma 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:3.2.3-slim
 
 EXPOSE 3000
 
-RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y build-essential libpq-dev nodejs npm
+RUN apt-get update && apt-get upgrade -y && apt-get install --no-install-recommends -y build-essential libpq-dev nodejs npm git
 
 # do the bundle install in another directory with the strict essential
 # (Gemfile and Gemfile.lock) to allow further steps to be cached

--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,7 @@ gem "sidekiq"
 
 gem "dry-transformer"
 
-gem "zipline"
+gem "zipline", github: "symmetRE-Inc/zipline"
 
 # payments: XML mapping
 gem "nokogiri"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,12 @@
+GIT
+  remote: https://github.com/symmetRE-Inc/zipline.git
+  revision: 9a2ea8bb2a067d73fe9ac4924f4c1b766414768c
+  specs:
+    zipline (1.5.0)
+      actionpack (>= 6.0, < 8.0)
+      content_disposition (~> 1.0)
+      zip_tricks (>= 4.2.1, < 6.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -297,6 +306,8 @@ GEM
     nio4r (2.7.0)
     nokogiri (1.16.0-aarch64-linux)
       racc (~> 1.4)
+    nokogiri (1.16.0-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.0-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -559,13 +570,10 @@ GEM
       nokogiri (~> 1.8)
     zeitwerk (2.6.12)
     zip_tricks (5.6.0)
-    zipline (1.5.0)
-      actionpack (>= 6.0, < 8.0)
-      content_disposition (~> 1.0)
-      zip_tricks (>= 4.2.1, < 6.0)
 
 PLATFORMS
   aarch64-linux
+  arm64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -624,7 +632,7 @@ DEPENDENCIES
   tzinfo-data
   web-console
   webmock
-  zipline
+  zipline!
 
 RUBY VERSION
    ruby 3.2.3p157

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aplypro
-  VERSION = "1.7.0"
+  VERSION = "1.7.1"
 end


### PR DESCRIPTION
Zipline has some issues with Puma 6/Rails 7[1] which weren't obvious until we upgraded to Puma 6. Use the patched version until the fix is merged to the main repo.

[1]: https://github.com/fringd/zipline/issues/91