### PR TITLE
payments: block the request when an adult student has an external rib

### DIFF
--- a/app/models/asp/payment_request_state_machine.rb
+++ b/app/models/asp/payment_request_state_machine.rb
@@ -31,7 +31,11 @@ module ASP
     end
 
     guard_transition(to: :ready) do |request|
-      ASP::StudentFileEligibilityChecker.new(request.payment.student).ready?
+      ASP::StudentFileEligibilityChecker.new(request.student).ready?
+    end
+
+    guard_transition(to: :ready) do |request|
+      !request.student.adult_without_personal_rib?
     end
 
     guard_transition(from: :ready, to: :sent) do |request|

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -69,6 +69,18 @@ class Student < ApplicationRecord
     address.blank?
   end
 
+  def underage?
+    birthdate > 18.years.ago
+  end
+
+  def adult?
+    !underage?
+  end
+
+  def adult_without_personal_rib?
+    adult? && !rib.personal?
+  end
+
   private
 
   def check_asp_file_reference

--- a/spec/factories/asp/payment_requests.rb
+++ b/spec/factories/asp/payment_requests.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
 
     trait :ready do
       after(:create) do |req|
-        req.payment.pfmp.student = create(:student, :with_all_asp_info)
+        req.payment.pfmp.student = create(:student, :with_all_asp_info, :underage)
 
         req.mark_ready!
       end

--- a/spec/factories/students.rb
+++ b/spec/factories/students.rb
@@ -69,5 +69,13 @@ FactoryBot.define do
 
       with_birthplace_info
     end
+
+    trait :underage do
+      birthdate { Faker::Date.birthday(min_age: 16, max_age: 17) }
+    end
+
+    trait :adult do
+      birthdate { Faker::Date.birthday(min_age: 18, max_age: 20) }
+    end
   end
 end

--- a/spec/lib/asp/entities/pers_physique_spec.rb
+++ b/spec/lib/asp/entities/pers_physique_spec.rb
@@ -8,6 +8,8 @@ describe ASP::Entities::PersPhysique, type: :model do
 
   before do
     payment_request.payment.schooling.update!(student: student)
+
+    payment_request.reload
   end
 
   describe "validation" do

--- a/spec/models/asp/payment_request_spec.rb
+++ b/spec/models/asp/payment_request_spec.rb
@@ -33,6 +33,19 @@ RSpec.describe ASP::PaymentRequest do
           expect { asp_payment_request.mark_ready! }.to raise_error Statesman::GuardFailedError
         end
       end
+
+      context "when the request belongs to a student over 18 with an external rib" do
+        let(:student) { create(:student, :with_all_asp_info, :adult) }
+
+        before do
+          asp_payment_request.payment.pfmp.update!(student: student)
+          student.rib.update!(personal: false)
+        end
+
+        it "blocks the transition" do
+          expect { asp_payment_request.mark_ready! }.to raise_error Statesman::GuardFailedError
+        end
+      end
     end
 
     describe "mark_as_sent!" do

--- a/spec/models/concerns/allowance_checker_spec.rb
+++ b/spec/models/concerns/allowance_checker_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 describe AllowanceChecker do
-  subject(:student) { create(:student, :with_all_asp_info) }
+  subject(:student) { create(:student, :with_all_asp_info, :underage) }
 
   let(:wage) { create(:wage, yearly_cap: 100, daily_rate: 10) }
   let(:mef) { create(:mef, code: "123", wage: wage) }


### PR DESCRIPTION
There are some details to be clarified, legally, when a student is over 18 and has a RIB that point to their (ex-)legal person.

We don't really know how to handle it quite yet in the UI, so just filter out the requests that target students over 18 with a RIB to someone else's name, and we'll come back to it as soon as we have more info.

Closes https://github.com/betagouv/aplypro/issues/398