### PR TITLE
payments: ensure we remove the file even if parsing goes wrong

### DIFF
--- a/app/jobs/poll_payments_server_job.rb
+++ b/app/jobs/poll_payments_server_job.rb
@@ -11,9 +11,13 @@ class PollPaymentsServerJob < ApplicationJob
 
       reader = ASP::FileReader.new(File.join(dir, file))
 
-      reader.parse!
-
-      ASP::Server.remove_file!(path: file) if reader.file_saved?
+      begin
+        reader.parse!
+      rescue ASP::Errors::ResponseFileParsingError, ASP::Errors::UnmatchedResponseFile => e
+        Sentry.capture_exception(e)
+      ensure
+        ASP::Server.remove_file!(path: file) if reader.file_saved?
+      end
     end
   end
 end

--- a/app/models/asp/errors.rb
+++ b/app/models/asp/errors.rb
@@ -3,6 +3,7 @@
 module ASP
   module Errors
     class Error < ::StandardError; end
+    class ResponseFileParsingError < Error; end
     class UnmatchedResponseFile < Error; end
     class SendingPaymentRequestInWrongState < Error; end
   end

--- a/lib/asp/file_reader.rb
+++ b/lib/asp/file_reader.rb
@@ -73,7 +73,13 @@ module ASP
     def parse!
       attach_to_request! unless payments_file?
 
-      reader_for(kind).new(File.read(filepath)).process!
+      reader = reader_for(kind).new(File.read(filepath))
+
+      begin
+        reader.process!
+      rescue StandardError => e
+        raise ResponseFileParsingError, "couldn't parse #{filename}: #{e}"
+      end
     end
 
     def file_saved?


### PR DESCRIPTION
We can always retry the parsing later as long as we've identified the request/response cycle correctly.