### PR TITLE
db: ensure we don't re-run through all mono schoolings

### DIFF
--- a/db/migrate/20240219100348_add_administrative_number_to_schoolings.rb
+++ b/db/migrate/20240219100348_add_administrative_number_to_schoolings.rb
@@ -13,8 +13,10 @@ class AddAdministrativeNumberToSchoolings < ActiveRecord::Migration[7.1]
 
     Schooling
       .with_attributive_decisions
-      .where(student_id: students.keys)
-      .find_in_batches do |models|
+      .where(student_id: students.keys, administrative_number: nil)
+      .find_in_batches.with_index do |models, idx|
+      Rails.logger.debug { "processing batch #{idx}..." }
+
       models.each { |schooling| schooling.administrative_number = students[schooling.student_id] }
 
       Schooling.upsert_all(models.map(&:attributes), update_only: [:administrative_number]) # rubocop:disable Rails/SkipsModelValidations


### PR DESCRIPTION
This morning we tried to release but the migration took too long to go through the 560K~ records that had to be updated. To circumvent the proble we went around and finished the migration by running the code in a separate worker where Scalingo grants us 40 minutes for a process instead of the 20 in a post-deploy hook (which is when our migrations normally run).

It went fine in a separate process but we don't want the migration to try and update all of these again so also check on `administrative_number: nil` and add some debugging I had earlier, even though it shouldn't print anything but batch 0.