### PR TITLE
db: avoid trying to upsert a PFMP twice

### DIFF
--- a/db/migrate/20240228153920_remove_payments.rb
+++ b/db/migrate/20240228153920_remove_payments.rb
@@ -13,7 +13,7 @@ class RemovePayments < ActiveRecord::Migration[7.1]
 
       pfmps = payments.map do |payment|
         payment.pfmp.tap { |pfmp| pfmp.amount = payment.amount }
-      end
+      end.uniq
 
       Pfmp.upsert_all(pfmps.map(&:attributes), update_only: [:amount]) # rubocop:disable Rails/SkipsModelValidations
     end


### PR DESCRIPTION
We got:

> [postdeploy-1827] PG::CardinalityViolation: ERROR:  ON CONFLICT DO UPDATE command cannot affect row a second time
> [postdeploy-1827] HINT:  Ensure that no rows proposed for insertion
> within the same command have duplicate constrained values.

when we tried to run the migration because we sometimes have (a bug that will solve itself) two payments per PFMP, which means the mapping would yield duplicate records, which upsets the UPSERT command.

Solve this by uniq-ing the array.