### PR TITLE
schoolings: simplify the administrative number generation

### DIFF
--- a/app/models/schooling.rb
+++ b/app/models/schooling.rb
@@ -29,8 +29,6 @@ class Schooling < ApplicationRecord
 
       break unless Schooling.exists?(administrative_number: administrative_number)
     end
-
-    self
   end
 
   def closed?

--- a/lib/attribute_decision_generator.rb
+++ b/lib/attribute_decision_generator.rb
@@ -17,8 +17,9 @@ class AttributeDecisionGenerator
 
   def generate!(file_descriptor)
     Schooling.transaction do
-      schooling.generate_administrative_number.tap(&:save!)
-      schooling.increment!(:attributive_decision_version)
+      schooling.generate_administrative_number
+      schooling.increment(:attributive_decision_version)
+      schooling.save!
 
       render
 

--- a/spec/factories/schoolings.rb
+++ b/spec/factories/schoolings.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
 
     trait :with_attributive_decision do
       after(:create) do |schooling|
-        schooling.generate_administrative_number.tap(&:save!)
+        schooling.tap(&:generate_administrative_number).save!
 
         schooling.rattach_attributive_decision!(StringIO.new("hello"))
       end


### PR DESCRIPTION
I wrote some dumb code that would tap/save! in the wrong order, which mean we had to return `self` always, and we didn't when there was an existing number.