### PR TITLE
guard: only watch relevant folders

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -4,8 +4,8 @@
 # More info at https://github.com/guard/guard#readme
 
 ## Uncomment and set this to only include directories you want to watch
-# directories %w(app lib config test spec features) \
-#  .select{|d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist")}
+directories(%w[app lib config spec features] \
+  .select { |d| Dir.exist?(d) ? d : UI.warning("Directory #{d} does not exist") })
 
 ## Note: if you are using the `directories` clause above and you are not
 ## watching the project directory ('.'), then you will want to move


### PR DESCRIPTION
prescriptum: je fais pas le mec à écrire des trucs en anglais c'est parce que GitHub prend le message du commit en description de PR s'il n'y en a qu'un...

This has been a huge issue for me, because my `tmp` folder was filling up, notably because of Active Storage's local storage (`tmp/storage`) and also because I use:

```
  db:
    volumes:
      - "./tmp/db:/var/lib/postgresql/data"
```

which means that my `tmp/db` folder contains *loads* of files, especially because I've had to create huge amounts of data lately for performance reasons.

Anyway, this meant inotify/listen/guard was trying to setup watchers on about ~160K files and got really, really slow. Circumvent this by only watching the relevant folder, namely the app and the tests. This makes Guard snappier than an angry French administrative. Yay!