### PR TITLE
payment fixer: scope the multiple PFMPs

### DIFF
--- a/lib/payment_fixer.rb
+++ b/lib/payment_fixer.rb
@@ -57,6 +57,7 @@ class PaymentFixer
     updates = []
 
     pfmps
+      .not_in_state(:pending)
       .group_by(&:mef)
       .each_value do |grouped_pfmps|
       grouped_pfmps.sort_by(&:created_at).inject(0) do |accumulated, pfmp|


### PR DESCRIPTION
The script finds all students with multiple PFMPs with a day count (ie. `not_in_state(:pending)`) but then calls the function with `student.pfmps`. Reintroduce the scope to avoid factoring in nil-day-count PFMPs.