### PR TITLE
asp: students born abroad are eligible without an address city code

### DIFF
--- a/app/models/concerns/asp/student_file_eligibility_checker.rb
+++ b/app/models/concerns/asp/student_file_eligibility_checker.rb
@@ -25,7 +25,11 @@ module ASP
       when :rib
         student.rib.present?
       when :birthplace_information
-        attributes_present? %i[birthplace_city_insee_code birthplace_country_insee_code]
+        required_attributes = [:birthplace_country_insee_code]
+
+        required_attributes.push(:birthplace_city_insee_code) if student.born_in_france?
+
+        attributes_present?(required_attributes)
       when :address_information
         attributes_present? %i[address_postal_code address_city_insee_code address_country_code]
       when :biological_sex

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -88,6 +88,10 @@ class Student < ApplicationRecord
     adult? && !rib.personal?
   end
 
+  def born_in_france?
+    InseeCodes.in_france?(birthplace_country_insee_code)
+  end
+
   private
 
   def check_asp_file_reference

--- a/app/services/insee_codes.rb
+++ b/app/services/insee_codes.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class InseeCodes
+  FRANCE_INSEE_COUNTRY_CODE = "99100"
+
+  class << self
+    def in_france?(code)
+      return false if code.blank?
+
+      InseeCountryCodeMapper.call(code) == FRANCE_INSEE_COUNTRY_CODE
+    end
+  end
+end

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aplypro
-  VERSION = "1.9.7"
+  VERSION = "1.9.8"
 end

--- a/lib/asp/entities/adresse.rb
+++ b/lib/asp/entities/adresse.rb
@@ -3,8 +3,6 @@
 module ASP
   module Entities
     class Adresse < Entity
-      FRANCE_INSEE_COUNTRY_CODE = "99100"
-
       attribute :codetypeadr, :string
       attribute :codecominsee, :string
       attribute :codeinseepays, :string
@@ -36,7 +34,7 @@ module ASP
       private
 
       def french_address?
-        codeinseepays == FRANCE_INSEE_COUNTRY_CODE
+        InseeCodes.in_france?(codeinseepays)
       end
 
       def foreign_address?

--- a/lib/asp/entities/pers_physique.rb
+++ b/lib/asp/entities/pers_physique.rb
@@ -35,7 +35,7 @@ module ASP
       private
 
       def born_in_france?
-        codeinseepaysnai == Adresse::FRANCE_INSEE_COUNTRY_CODE
+        InseeCodes.in_france?(codeinseepaysnai)
       end
     end
   end

--- a/spec/models/concerns/asp/student_file_eligibility_checker_spec.rb
+++ b/spec/models/concerns/asp/student_file_eligibility_checker_spec.rb
@@ -17,10 +17,28 @@ describe ASP::StudentFileEligibilityChecker do
     it { is_expected.not_to be_ready }
   end
 
-  context "when the student is missing birthplace info" do
-    before { student.update!(birthplace_country_insee_code: nil) }
+  context "when the student is born in France" do
+    let(:student) { create(:student, :with_all_asp_info, :born_in_france) }
 
-    it { is_expected.not_to be_ready }
+    context "without city information" do
+      before { student.update!(birthplace_city_insee_code: nil) }
+
+      it { is_expected.not_to be_ready }
+    end
+
+    context "with city information" do
+      it { is_expected.to be_ready }
+    end
+  end
+
+  context "when the student was born abroad" do
+    let(:student) { create(:student, :with_all_asp_info, :born_abroad) }
+
+    context "without city information" do
+      before { student.update!(birthplace_city_insee_code: nil) }
+
+      it { is_expected.to be_ready }
+    end
   end
 
   context "when the student is missing some address info" do


### PR DESCRIPTION
The logic is "you need a city code if you were born in France"; this was correctly implemented in the ASP code but the
StudentFileEligibilityChecker was being overly strict without it.