### PR TITLE
payment requests: don't let the factory create duplicate requests

### DIFF
--- a/spec/factories/asp/payment_requests.rb
+++ b/spec/factories/asp/payment_requests.rb
@@ -2,9 +2,10 @@
 
 FactoryBot.define do
   factory :asp_payment_request, class: "ASP::PaymentRequest" do
-    pfmp { association :pfmp, :validated, schooling: schooling }
+    initialize_with { pfmp.payment_requests.last }
 
     transient do
+      pfmp { association :pfmp, :validated, schooling: schooling }
       student { association :student, :with_all_asp_info, :underage }
       schooling { association :schooling, :with_attributive_decision, student: student }
     end

--- a/spec/models/asp/payment_request_spec.rb
+++ b/spec/models/asp/payment_request_spec.rb
@@ -8,4 +8,10 @@ RSpec.describe ASP::PaymentRequest do
   describe "associations" do
     it { is_expected.to belong_to(:asp_request).optional }
   end
+
+  describe "factory" do
+    it "does not create extra payment requests" do
+      expect { create(:asp_payment_request) }.to change(described_class, :count).by(1)
+    end
+  end
 end

--- a/spec/services/asp/readers/payments_file_reader_spec.rb
+++ b/spec/services/asp/readers/payments_file_reader_spec.rb
@@ -36,7 +36,8 @@ describe ASP::Readers::PaymentsFileReader do
     let(:payment_state) { :success }
 
     before do
-      create(:asp_payment_request, :integrated, pfmp: asp_payment_request.pfmp)
+      create(:asp_payment_request, :integrated)
+        .update!(pfmp: asp_payment_request.pfmp)
     end
 
     it "raises an error" do


### PR DESCRIPTION
Because a payment request only makes sense in the context of a validated PFMP (mostly because it requires a positive amount), we generate a validated PFMP in the factory. But because of the – legitimate – callback that triggers a payment creation when a PFMP is validated, the chain goes like this:

create(:payment_request, :ready) ->
  create(:pfmp, :validated) ->
    pfmp.setup_payment! ->
      pfmp.payment_requests.create!  # (A)
  pfmp.payment_requests << the actual factory request (B)

This means request A is immediately forgotten and create a strange zombie state for the PFMP.

Instead we can use the initialize_with block of FactoryBot to rewire the logic and re-use the payment request that is created as part of the validation request.