### PR TITLE
asp: don't reinclude the data of known ASP entities

### DIFF
--- a/lib/asp/entities/.rubocop.yml
+++ b/lib/asp/entities/.rubocop.yml
@@ -1,0 +1,11 @@
+inherit_from:
+  - ../../../.rubocop.yml
+
+# in the ASP entities building code (i.e this folder) we make a lot of
+# calls to the same XML builder objet (`xml.tag(content)`), which
+# offends Rubocop because it looks like high ABC complexity. Minimise
+# the drama by allowing repeated attributes which means a bunch of
+# calls to the same `xml` object are not accumulated and greatly
+# reduces the initial offense count.
+Metrics/AbcSize:
+  CountRepeatedAttributes: false

--- a/lib/asp/entities/dossier.rb
+++ b/lib/asp/entities/dossier.rb
@@ -11,15 +11,24 @@ module ASP
       attribute :id_dossier, :string
       attribute :codedispositif, :string
 
+      known_with :id_dossier
+
       validates_presence_of %i[numadm codedispositif]
 
       def xml_root_args
-        { idDoss: id_dossier, **ASP_NO_MODIFICATION } if id_dossier.present?
+        if known_record?
+          { idDoss: id_dossier, **ASP_NO_MODIFICATION }
+        else
+          {}
+        end
       end
 
       def fragment(xml)
-        xml.numadm(numadm)
-        xml.codedispositif(codedispositif)
+        if new_record?
+          xml.numadm(numadm)
+          xml.codedispositif(codedispositif)
+        end
+
         xml.listeprestadoss do
           Prestadoss.from_payment_request(payment_request).to_xml(xml)
         end

--- a/lib/asp/entities/enregistrement.rb
+++ b/lib/asp/entities/enregistrement.rb
@@ -12,6 +12,8 @@ module ASP
 
       validates_presence_of :id_enregistrement
 
+      known_with :id_individu
+
       def xml_root_args
         { idEnregistrement: id_enregistrement }
       end
@@ -21,17 +23,22 @@ module ASP
       end
 
       def individu(xml)
-        xml.natureindividu("P")
-        PersPhysique.from_payment_request(payment_request).to_xml(xml)
-        xml.adressesindividu { Adresse.from_payment_request(payment_request).to_xml(xml) }
-        xml.coordpaiesindividu { CoordPaie.from_payment_request(payment_request).to_xml(xml) }
+        if new_record?
+          xml.natureindividu("P")
+          PersPhysique.from_payment_request(payment_request).to_xml(xml)
+          xml.adressesindividu { Adresse.from_payment_request(payment_request).to_xml(xml) }
+          xml.coordpaiesindividu { CoordPaie.from_payment_request(payment_request).to_xml(xml) }
+        end
+
         xml.listedossier { Dossier.from_payment_request(payment_request).to_xml(xml) }
       end
 
       def individu_attrs
-        return {} if id_individu.blank?
-
-        { idIndividu: id_individu, **ASP_NO_MODIFICATION }
+        if known_record?
+          { idIndividu: id_individu, **ASP_NO_MODIFICATION }
+        else
+          {}
+        end
       end
     end
   end

--- a/lib/asp/entities/entity.rb
+++ b/lib/asp/entities/entity.rb
@@ -33,6 +33,11 @@ module ASP
             instance.assign_attributes(mapped_attributes)
           end
         end
+
+        def known_with(attr)
+          define_method(:new_record?) { send(attr).blank? }
+          define_method(:known_record?) { !new_record? }
+        end
       end
 
       def xml_root_args

--- a/lib/asp/entities/prestadoss.rb
+++ b/lib/asp/entities/prestadoss.rb
@@ -14,10 +14,16 @@ module ASP
       attribute :montanttotalengage, :string
       attribute :valeur, :string
 
+      known_with :id_prestation_dossier
+
       validates_presence_of %i[numadm datecomplete datereceptionprestadoss montanttotalengage valeur]
 
       def xml_root_args
-        { idPrestaDoss: id_prestation_dossier, **ASP_NO_MODIFICATION } if id_prestation_dossier.present?
+        if known_record?
+          { idPrestaDoss: id_prestation_dossier, **ASP_NO_MODIFICATION }
+        else
+          {}
+        end
       end
 
       def fragment(xml)

--- a/spec/lib/asp/entities/dossier_spec.rb
+++ b/spec/lib/asp/entities/dossier_spec.rb
@@ -27,6 +27,12 @@ describe ASP::Entities::Dossier, type: :model do
       it "passes the modification false to flag" do
         expect(attributes["modification"]).to have_attributes value: "N"
       end
+
+      %w[numadm codedispositif].each do |attr|
+        it "does not reinclude the #{attr} attribute" do
+          expect(document.at(attr)).to be_nil
+        end
+      end
     end
   end
 end

--- a/spec/lib/asp/entities/enregistrement_spec.rb
+++ b/spec/lib/asp/entities/enregistrement_spec.rb
@@ -30,6 +30,12 @@ describe ASP::Entities::Enregistrement, type: :model do
         it "includes the modification flag to false" do
           expect(attributes["modification"]).to have_attributes value: "N"
         end
+
+        %w[persphysique adressesindividu coordpaiesindividu].each do |entity|
+          it "does not reinclude the #{entity} entity" do
+            expect(document.at(entity)).to be_nil
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
Reincluding the data might cause some parsing failures on their side, as we've been told in an email:

> Effectivement c'est une erreur peu compréhensible. Pour ajouter une
> prestation dossier sur un dossier, le plus simple est d'envoyer
> l'individu et le dossier avec l'attribut modification=N mais sans
> balises, comme ceci :

> <ENREGISTREMENT idEnregistrement="313">
>   <INDIVIDU idIndividu="702631849" modification="N">
>     <LISTEDOSSIER>
>       <DOSSIER idDoss="704141913" modification="N">
>         <LISTEPRESTADOSS>
>           <PRESTADOSS>

Closes #629.