### PR TITLE
Fix/asp reincluded attrs

### DIFF
--- a/app/models/asp/errors.rb
+++ b/app/models/asp/errors.rb
@@ -6,5 +6,6 @@ module ASP
     class ResponseFileParsingError < Error; end
     class UnmatchedResponseFile < Error; end
     class SendingPaymentRequestInWrongState < Error; end
+    class RerunningParsedRequest < Error; end
   end
 end

--- a/app/models/asp/request.rb
+++ b/app/models/asp/request.rb
@@ -11,6 +11,8 @@ module ASP
     attr_reader :asp_file
 
     def send!(rerun: false)
+      raise ASP::Errors::RerunningParsedRequest if results_attached?
+
       ActiveRecord::Base.transaction do
         @asp_file = ASP::Entities::Fichier.new(asp_payment_requests)
 
@@ -44,6 +46,12 @@ module ASP
         content_type: "text/xml",
         filename: @asp_file.filename
       )
+    end
+
+    private
+
+    def results_attached?
+      integrations_file.attached? || rejects_file.attached?
     end
   end
 end

--- a/lib/asp/entities/dossier.rb
+++ b/lib/asp/entities/dossier.rb
@@ -24,10 +24,8 @@ module ASP
       end
 
       def fragment(xml)
-        if new_record?
-          xml.numadm(numadm)
-          xml.codedispositif(codedispositif)
-        end
+        xml.numadm(numadm)
+        xml.codedispositif(codedispositif)
 
         xml.listeprestadoss do
           Prestadoss.from_payment_request(payment_request).to_xml(xml)

--- a/spec/lib/asp/entities/dossier_spec.rb
+++ b/spec/lib/asp/entities/dossier_spec.rb
@@ -27,12 +27,6 @@ describe ASP::Entities::Dossier, type: :model do
       it "passes the modification false to flag" do
         expect(attributes["modification"]).to have_attributes value: "N"
       end
-
-      %w[numadm codedispositif].each do |attr|
-        it "does not reinclude the #{attr} attribute" do
-          expect(document.at(attr)).to be_nil
-        end
-      end
     end
   end
 end

--- a/spec/models/asp/request_spec.rb
+++ b/spec/models/asp/request_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe ASP::Request do
       expect(payment_requests.map(&:asp_request_id).uniq).to contain_exactly(request.id)
     end
 
+    context "with an existing rejects file" do
+      before { request.rejects_file.attach(io: StringIO.new("rejects"), filename: "rejects") }
+
+      it "refuses to run" do
+        expect { request.send! }.to raise_error ASP::Errors::RerunningParsedRequest
+      end
+    end
+
+    context "with an existing integrations file" do
+      before { request.integrations_file.attach(io: StringIO.new("rejects"), filename: "rejects") }
+
+      it "refuses to run" do
+        expect { request.send! }.to raise_error ASP::Errors::RerunningParsedRequest
+      end
+    end
+
     shared_examples "does not persist anything" do
       it "does not update the sent_at timestamp" do
         expect { request.send! rescue RuntimeError } # rubocop:disable Style/RescueModifier


### PR DESCRIPTION
+ajout d'un garde pour éviter l'envoi de requêtes avec résultats (i.e un fichier d'intégrations ou de rejets)