### PR TITLE
establishment: fix the departement code

### DIFF
--- a/app/models/establishment.rb
+++ b/app/models/establishment.rb
@@ -66,8 +66,12 @@ class Establishment < ApplicationRecord
     [uai, name].compact.join(" - ")
   end
 
-  def region_code
-    postal_code.first(2)
+  def department_code
+    if postal_code.start_with?("97")
+      postal_code.first(3)
+    else
+      postal_code.first(2)
+    end
   end
 
   def address

--- a/app/services/asp/mappers/prestadoss_mapper.rb
+++ b/app/services/asp/mappers/prestadoss_mapper.rb
@@ -27,7 +27,7 @@ module ASP
       end
 
       def valeur
-        schooling.establishment.region_code.rjust(3, "0")
+        schooling.establishment.department_code.rjust(3, "0")
       end
 
       def id_prestation_dossier

--- a/spec/models/establishment_spec.rb
+++ b/spec/models/establishment_spec.rb
@@ -48,4 +48,22 @@ RSpec.describe Establishment do
       it { is_expected.not_to be_valid }
     end
   end
+
+  describe "department_code" do
+    context "when it's from metropolitan France" do
+      before { establishment.update!(postal_code: "34070") }
+
+      it "is the first 2 characters" do
+        expect(establishment.department_code).to eq "34"
+      end
+    end
+
+    context "when it is from overseas France" do
+      before { establishment.update!(postal_code: "97492") }
+
+      it "is the first 3 characters" do
+        expect(establishment.department_code).to eq "974"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Overseas (la Réunion, Martinique, etc.) are 3-characters long, which we didn't account for previously.