### PR TITLE
establishments: fix the department code logic

### DIFF
--- a/app/models/establishment.rb
+++ b/app/models/establishment.rb
@@ -45,7 +45,8 @@ class Establishment < ApplicationRecord
     "telephone" => :telephone,
     "mail" => :email,
     "code_type_contrat_prive" => :private_contract_type_code,
-    "ministere_tutelle" => :ministry
+    "ministere_tutelle" => :ministry,
+    "code_departement" => :department_code
   }.freeze
 
   # Find all codes here : https://infocentre.pleiade.education.fr/bcn/workspace/viewTable/n/N_CONTRAT_ETABLISSEMENT
@@ -64,14 +65,6 @@ class Establishment < ApplicationRecord
 
   def select_label
     [uai, name].compact.join(" - ")
-  end
-
-  def department_code
-    if postal_code.start_with?("97")
-      postal_code.first(3)
-    else
-      postal_code.first(2)
-    end
   end
 
   def address

--- a/app/services/asp/mappers/prestadoss_mapper.rb
+++ b/app/services/asp/mappers/prestadoss_mapper.rb
@@ -27,7 +27,7 @@ module ASP
       end
 
       def valeur
-        schooling.establishment.department_code.rjust(3, "0")
+        schooling.establishment.department_code
       end
 
       def id_prestation_dossier

--- a/db/migrate/20240402090724_add_department_code_to_establishments.rb
+++ b/db/migrate/20240402090724_add_department_code_to_establishments.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddDepartmentCodeToEstablishments < ActiveRecord::Migration[7.1]
+  def change
+    add_column :establishments, :department_code, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_21_161647) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_02_090724) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -128,6 +128,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_21_161647) do
     t.string "students_provider"
     t.string "ministry"
     t.bigint "confirmed_director_id"
+    t.string "department_code"
     t.index ["confirmed_director_id"], name: "index_establishments_on_confirmed_director_id"
     t.index ["uai"], name: "index_establishments_on_uai", unique: true
   end

--- a/spec/factories/establishments.rb
+++ b/spec/factories/establishments.rb
@@ -18,6 +18,12 @@ FactoryBot.define do
     confirmed_director { nil }
     department_code { "034" }
 
+    trait :dehydrated do
+      Establishment::API_MAPPING.each_value do |field|
+        send(field) { nil }
+      end
+    end
+
     trait :private do
       private_contract_type_code { "31" }
     end

--- a/spec/factories/establishments.rb
+++ b/spec/factories/establishments.rb
@@ -16,6 +16,7 @@ FactoryBot.define do
     students_provider { nil }
     ministry { "MINISTERE DE L'EDUCATION NATIONALE" }
     confirmed_director { nil }
+    department_code { "034" }
 
     trait :private do
       private_contract_type_code { "31" }

--- a/spec/models/establishment_spec.rb
+++ b/spec/models/establishment_spec.rb
@@ -48,22 +48,4 @@ RSpec.describe Establishment do
       it { is_expected.not_to be_valid }
     end
   end
-
-  describe "department_code" do
-    context "when it's from metropolitan France" do
-      before { establishment.update!(postal_code: "34070") }
-
-      it "is the first 2 characters" do
-        expect(establishment.department_code).to eq "34"
-      end
-    end
-
-    context "when it is from overseas France" do
-      before { establishment.update!(postal_code: "97492") }
-
-      it "is the first 3 characters" do
-        expect(establishment.department_code).to eq "974"
-      end
-    end
-  end
 end


### PR DESCRIPTION
Closes #659 

NOTE: pour la correction des données (i.e réhydrater les établissements avec leur code département), je propose qu'on le fasse à la main ce soir, on a 4578 établissements je pense pas que ce soit trop dur. En sachant que les données sont [automatiquement rafraîchies à chaque connexion](https://github.com/betagouv/aplypro/blob/main/app/controllers/users/omniauth_callbacks_controller.rb#L162).
commit:
```
... by directly storing it from the API which already provides a
three-digit, INSEE-compliant, 0-padded department code.

> %w[9740082W 7200011Z 0340045P].map { |uai| EstablishmentApi.fetch!(uai)["records"][0]["fields"]["code_departement"] }
> ["974", "02B", "034"]
> # La Réunion, Haute-Corse, Hérault
```