### PR TITLE
rib: remove the duplicate RIB check

### DIFF
--- a/app/models/asp/payment_request_state_machine.rb
+++ b/app/models/asp/payment_request_state_machine.rb
@@ -46,10 +46,6 @@ module ASP
     end
 
     guard_transition(to: :ready) do |request|
-      !request.student.rib.reused?
-    end
-
-    guard_transition(to: :ready) do |request|
       request.student.rib.valid?
     end
 

--- a/app/models/rib.rb
+++ b/app/models/rib.rb
@@ -6,8 +6,6 @@ class Rib < ApplicationRecord
   validates :iban, :bic, :name, presence: true
   validates :student_id, uniqueness: { scope: :archived_at }, if: :active?
 
-  scope :not_reused, -> { Rib.where.not(iban: Rib.multiple_ibans) }
-  scope :reused, -> { Rib.where(iban: Rib.multiple_ibans) }
   scope :multiple_ibans, -> { Rib.select(:iban).group(:iban).having("count(iban) > 1") }
 
   normalizes :bic, :iban, with: ->(value) { value.gsub(/\s+/, "").upcase }
@@ -39,13 +37,5 @@ class Rib < ApplicationRecord
 
   def inactive?
     !active?
-  end
-
-  def reused?
-    siblings.any?
-  end
-
-  def siblings
-    Rib.where(iban: iban).excluding(self)
   end
 end

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -41,7 +41,6 @@ class Student < ApplicationRecord
 
   def self.asp_ready
     joins(:rib)
-      .merge(Rib.not_reused)
       .lives_in_france
       .with_ine
       .with_biological_sex

--- a/spec/models/asp/payment_request_state_machine_spec.rb
+++ b/spec/models/asp/payment_request_state_machine_spec.rb
@@ -48,12 +48,6 @@ describe ASP::PaymentRequestStateMachine do
       it_behaves_like "a blocked request"
     end
 
-    context "when the RIB has been reused somewhere else" do
-      before { create(:rib, iban: asp_payment_request.student.rib.iban) }
-
-      it_behaves_like "a blocked request"
-    end
-
     # rubocop:disable Rails/SkipsModelValidations
     context "when the PFMP is not valid" do
       before { asp_payment_request.pfmp.update_column(:start_date, Date.new(2002, 1, 1)) }

--- a/spec/models/rib_spec.rb
+++ b/spec/models/rib_spec.rb
@@ -61,28 +61,4 @@ RSpec.describe Rib do
       end
     end
   end
-
-  describe "reused?" do
-    context "without other ribs" do
-      it "is false" do
-        expect(rib).not_to be_reused
-      end
-
-      it "is included in the scope" do
-        expect(described_class.not_reused).to include(rib)
-      end
-    end
-
-    context "with multiple RIBS with the same IBAN" do
-      before { create(:rib, iban: rib.iban) }
-
-      it "returns true" do
-        expect(rib).to be_reused
-      end
-
-      it "is not included in the unique scope" do
-        expect(described_class.not_reused).not_to include(rib)
-      end
-    end
-  end
 end


### PR DESCRIPTION
It was just a heuristic to avoid some legal issues with students under guardianship. We've actually got a (private) list of students to ignore now, which we're going to hack into our PFMP selection logic now and leave the rest of the code alone. This means siblings (i.e the canonical example of 1 rib = multiple students) can get through again and the query/checks are less expensive.