### PR TITLE
asp: pass an actual file object to the file handler

### DIFF
--- a/app/jobs/poll_payments_server_job.rb
+++ b/app/jobs/poll_payments_server_job.rb
@@ -18,7 +18,7 @@ class PollPaymentsServerJob < ApplicationJob
       rescue ASP::Errors::ResponseFileParsingError, ASP::Errors::UnmatchedResponseFile => e
         Sentry.capture_exception(e)
       ensure
-        ASP::Server.remove_file!(path: filename) if handler.file_saved?
+        ASP::Server.remove_file!(filename: filename) if handler.file_saved?
       end
     end
   end

--- a/app/jobs/poll_payments_server_job.rb
+++ b/app/jobs/poll_payments_server_job.rb
@@ -6,17 +6,19 @@ class PollPaymentsServerJob < ApplicationJob
   def perform
     dir = ASP::Server.get_all_files!
 
-    Dir.each_child(dir) do |file|
-      next if file == ".keep" # these are the Git-keep files of our local dev
+    Dir.each_child(dir) do |filename|
+      next if filename == ".keep" # these are the Git-keep files of our local dev
 
-      handler = ASP::FileHandler.new(File.join(dir, file))
+      file = File.open(File.join(dir, filename))
+
+      handler = ASP::FileHandler.new(file)
 
       begin
         handler.parse!
       rescue ASP::Errors::ResponseFileParsingError, ASP::Errors::UnmatchedResponseFile => e
         Sentry.capture_exception(e)
       ensure
-        ASP::Server.remove_file!(path: file) if handler.file_saved?
+        ASP::Server.remove_file!(path: filename) if handler.file_saved?
       end
     end
   end

--- a/features/accueil_status_des_paiements.feature
+++ b/features/accueil_status_des_paiements.feature
@@ -48,8 +48,8 @@ Fonctionnalité: Aperçu des paiements par status dans la page d'accueil
 
   Scénario: Le personnel de direction voit une demande de paiement rejetée à l'intégration
     Sachant que les tâches de préparation et d'envoi des paiements sont passées
-    Et que l'ASP a rejetté le dossier de "Marie Curie" avec un motif de "mauvais code postal"
-    Et que la tâche de lecture des paiements est passée
+    Et que l'ASP a rejetté le dossier de "Marie Curie" avec un motif de "bic erronné"
+    Quand la tâche de lecture des paiements est passée
     Et que je rafraîchis la page
     Alors l'indicateur de demandes de paiements "En attente" affiche 0
     Et l'indicateur de demandes de paiements "En traitement" affiche 0

--- a/lib/asp/server.rb
+++ b/lib/asp/server.rb
@@ -18,8 +18,8 @@ module ASP
         end
       end
 
-      def remove_file!(path:)
-        instance.connection.remove!(File.join(READ_FOLDER, path))
+      def remove_file!(filename:)
+        instance.connection.remove!(File.join(READ_FOLDER, filename))
       end
 
       def instance

--- a/spec/jobs/poll_payments_server_job_spec.rb
+++ b/spec/jobs/poll_payments_server_job_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe PollPaymentsServerJob do
     it "deletes it on the server" do
       perform_enqueued_jobs { described_class.perform_later }
 
-      expect(server_double).to have_received(:remove_file!).with(path: basename)
+      expect(server_double).to have_received(:remove_file!).with(filename: basename)
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe PollPaymentsServerJob do
     it "does not remove the file off the server" do
       perform_enqueued_jobs { described_class.perform_later }
 
-      expect(server_double).not_to have_received(:remove_file!).with(path: basename)
+      expect(server_double).not_to have_received(:remove_file!).with(filename: basename)
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.describe PollPaymentsServerJob do
       it "deletes it on the server" do
         perform_enqueued_jobs { described_class.perform_later }
 
-        expect(server_double).to have_received(:remove_file!).with(path: basename)
+        expect(server_double).to have_received(:remove_file!).with(filename: basename)
       end
     end
 
@@ -80,7 +80,7 @@ RSpec.describe PollPaymentsServerJob do
       it "doesn't delete it on the server" do
         perform_enqueued_jobs { described_class.perform_later }
 
-        expect(server_double).not_to have_received(:remove_file!).with(path: basename)
+        expect(server_double).not_to have_received(:remove_file!).with(filename: basename)
       end
     end
   end

--- a/spec/jobs/poll_payments_server_job_spec.rb
+++ b/spec/jobs/poll_payments_server_job_spec.rb
@@ -8,14 +8,16 @@ RSpec.describe PollPaymentsServerJob do
   let(:server_double) { class_double(ASP::Server) }
   let(:reader_double) { class_double(ASP::FileHandler) }
   let(:double) { instance_double(ASP::FileHandler) }
+  let(:mock_file) { Tempfile.create }
+  let(:basename) { File.basename(mock_file) }
 
   before do
     stub_const("ASP::Server", server_double)
     stub_const("ASP::FileHandler", reader_double)
 
-    allow(Dir).to receive(:each_child).and_yield("foobar")
+    allow(Dir).to receive(:each_child).and_yield(basename)
 
-    allow(server_double).to receive(:get_all_files!).and_return("some/folder")
+    allow(server_double).to receive(:get_all_files!).and_return(File.dirname(mock_file))
     allow(server_double).to receive(:remove_file!)
 
     allow(reader_double).to receive(:new).and_return double
@@ -41,7 +43,7 @@ RSpec.describe PollPaymentsServerJob do
     it "deletes it on the server" do
       perform_enqueued_jobs { described_class.perform_later }
 
-      expect(server_double).to have_received(:remove_file!).with(path: "foobar")
+      expect(server_double).to have_received(:remove_file!).with(path: basename)
     end
   end
 
@@ -53,7 +55,7 @@ RSpec.describe PollPaymentsServerJob do
     it "does not remove the file off the server" do
       perform_enqueued_jobs { described_class.perform_later }
 
-      expect(server_double).not_to have_received(:remove_file!).with(path: "foobar")
+      expect(server_double).not_to have_received(:remove_file!).with(path: basename)
     end
   end
 
@@ -68,7 +70,7 @@ RSpec.describe PollPaymentsServerJob do
       it "deletes it on the server" do
         perform_enqueued_jobs { described_class.perform_later }
 
-        expect(server_double).to have_received(:remove_file!).with(path: "foobar")
+        expect(server_double).to have_received(:remove_file!).with(path: basename)
       end
     end
 
@@ -78,7 +80,7 @@ RSpec.describe PollPaymentsServerJob do
       it "doesn't delete it on the server" do
         perform_enqueued_jobs { described_class.perform_later }
 
-        expect(server_double).not_to have_received(:remove_file!).with(path: "foobar")
+        expect(server_double).not_to have_received(:remove_file!).with(path: basename)
       end
     end
   end

--- a/spec/services/asp/file_handler_spec.rb
+++ b/spec/services/asp/file_handler_spec.rb
@@ -3,11 +3,11 @@
 require "rails_helper"
 
 describe ASP::FileHandler do
-  subject(:reader) { described_class.new(filepath) }
+  subject(:reader) { described_class.new(file) }
 
   let(:request_identifier) { "foobar" }
   let!(:request) { create(:asp_request, :sent, filename: "#{request_identifier}.xml") }
-  let(:filepath) { File.new(File.join(Dir.mktmpdir, basename), "w+").path }
+  let(:file) { File.new(File.join(Dir.mktmpdir, basename), "w+") }
 
   # can't reduce much more
   # rubocop:disable Rspec/MultipleMemoizedHelpers


### PR DESCRIPTION
I'm not sure why I wrote the initial version passing a filename rather than an actual File object. Not only that but the call to:

-      handler = ASP::FileHandler.new(File.join(dir, file))

seems to have yielded things like:

"-tmp-aplypro_asp20240411-22-ntjttg-identifiants_generes_nps_ficimport_idp_aplypro_production_20240410164029.csv"

in production which we'll have to fix by hand. This new version is a lot more sane because it iterates through the directory, makes a file object and then feeds it to the handler which now only has a `file` attribute.