### PR TITLE
Raise error on missing translations in production 

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -92,4 +92,7 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
+  # Raises error for missing translations.
+  config.i18n.raise_on_missing_translations = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
   config.active_support.disallowed_deprecation_warnings = []
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true


### PR DESCRIPTION
So that we can see the errors in Sentry pop up