### PR TITLE
jobs: don't retry SendPaymentRequestsJob if the XML validation fails

### DIFF
--- a/app/jobs/send_payment_requests_job.rb
+++ b/app/jobs/send_payment_requests_job.rb
@@ -3,6 +3,8 @@
 class SendPaymentRequestsJob < ApplicationJob
   queue_as :default
 
+  discard_on ASP::Errors::XMLValidationFailed
+
   def perform(payment_requests)
     ActiveRecord::Base.transaction do
       ASP::Request

--- a/app/models/asp/errors.rb
+++ b/app/models/asp/errors.rb
@@ -7,5 +7,6 @@ module ASP
     class UnmatchedResponseFile < Error; end
     class SendingPaymentRequestInWrongState < Error; end
     class RerunningParsedRequest < Error; end
+    class XMLValidationFailed < Error; end
   end
 end

--- a/app/models/asp/request.rb
+++ b/app/models/asp/request.rb
@@ -16,7 +16,11 @@ module ASP
       ActiveRecord::Base.transaction do
         @asp_file = ASP::Entities::Fichier.new(asp_payment_requests)
 
-        @asp_file.validate!
+        begin
+          @asp_file.validate!
+        rescue ActiveRecord::RecordInvalid
+          raise ASP::Errors::XMLValidationFailed
+        end
 
         attach_asp_file!
         drop_file!

--- a/spec/models/asp/request_spec.rb
+++ b/spec/models/asp/request_spec.rb
@@ -73,9 +73,13 @@ RSpec.describe ASP::Request do
     end
 
     context "when the XML is not valid" do
-      before { allow(double).to receive(:validate!).and_raise }
+      before { allow(double).to receive(:validate!).and_raise ActiveRecord::RecordInvalid }
 
       include_examples "does not persist anything"
+
+      it "raises a specific error" do
+        expect { request.send! }.to raise_error ASP::Errors::XMLValidationFailed
+      end
     end
 
     context "when the server can't upload the file" do


### PR DESCRIPTION
When the XML validation fails there is no point retrying the job: if it failed formatting the first time it will fail the second time.

Closes #711.