### PR TITLE
asp: check the payment requests state before sending

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,10 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
-  global:
-    service_name: "Your service"
-    service_description: "Your service's description"
+  activerecord:
+    errors:
+      models:
+        asp/request:
+          attributes:
+            base:
+              requests_in_wrong_state: some of the ASP::PaymentRequest are not in the ready state

--- a/spec/factories/asp/requests.rb
+++ b/spec/factories/asp/requests.rb
@@ -10,8 +10,16 @@ FactoryBot.define do
     end
 
     trait :sent do
+      with_request
+
       after(:create) do |request, ctx|
         request.file.attach(io: StringIO.new(ctx.outfile), filename: ctx.filename)
+      end
+    end
+
+    trait :with_request do
+      after(:build) do |request|
+        request.asp_payment_requests << create(:asp_payment_request, :ready)
       end
     end
   end

--- a/spec/jobs/send_payment_requests_job_spec.rb
+++ b/spec/jobs/send_payment_requests_job_spec.rb
@@ -55,11 +55,11 @@ RSpec.describe SendPaymentRequestsJob do
 
     it "raises an error" do
       expect { described_class.perform_now([payment_request]) }
-        .to raise_error ASP::Errors::SendingPaymentRequestInWrongState
+        .to raise_error ActiveRecord::RecordInvalid
     end
 
     it "does not persist the request" do
-      suppress(ASP::Errors::SendingPaymentRequestInWrongState) do
+      suppress(ActiveRecord::RecordInvalid) do
         expect { described_class.perform_now([payment_request]) }.not_to change(ASP::Request, :count)
       end
     end

--- a/spec/models/asp/payment_request_spec.rb
+++ b/spec/models/asp/payment_request_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe ASP::PaymentRequest do
   end
 
   describe "factory" do
+    ASP::PaymentRequestStateMachine.states.each do |state|
+      it "has a valid '#{state}' factory" do
+        expect(create(:asp_payment_request, state)).to be_valid
+      end
+    end
+
     it "does not create extra payment requests" do
       expect { create(:asp_payment_request) }.to change(described_class, :count).by(1)
     end

--- a/spec/models/asp/request_spec.rb
+++ b/spec/models/asp/request_spec.rb
@@ -29,8 +29,18 @@ RSpec.describe ASP::Request do
     it { is_expected.to validate_length_of(:asp_payment_requests).is_at_most(7000) }
   end
 
+  describe "when a payment request is not in the right state" do
+    let(:payment_request) { create(:asp_payment_request, :sent) }
+
+    it "fails creation" do
+      expect do
+        described_class.create!(asp_payment_requests: [payment_request])
+      end.to raise_error(/not in the ready state/)
+    end
+  end
+
   describe "scopes" do
-    let(:request) { create(:asp_request, :sent, sent_at: sent_at) }
+    let(:request) { create(:asp_request, :sent, :with_request, sent_at: sent_at) }
 
     describe "sent_today" do
       subject { described_class.sent_today }


### PR DESCRIPTION
We've ran into a huge problem with a SendPaymentRequestsJob erroring out, which means Sidekiq retried it a bunch of times. Everything runs in a transaction but that does not stop the job from depositing the file on the ASP server where we can't just take it back if something goes wrong after.

Add a validation to make sure we only create ASP::Requests with ASP::PaymentRequests in ready state, but only do it on create because we might want to send back (`send!(rerun: true)`) some requests that have crashed on the ASP server ie. before rejection or integration, if their validation catches something our XML schema missed.