### PR TITLE
workers: add a dedicated worker for the payments

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,5 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -v
 workerdoc: bundle exec sidekiq --queue documents
+payments: bundle exec sidekiq --queue payments
 postdeploy: bundle exec rails db:prepare

--- a/app/jobs/poll_payments_server_job.rb
+++ b/app/jobs/poll_payments_server_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PollPaymentsServerJob < ApplicationJob
-  queue_as :default
+  queue_as :payments
 
   def perform
     dir = ASP::Server.get_all_files!

--- a/app/jobs/poll_payments_server_job.rb
+++ b/app/jobs/poll_payments_server_job.rb
@@ -3,6 +3,8 @@
 class PollPaymentsServerJob < ApplicationJob
   queue_as :payments
 
+  sidekiq_options retry: false
+
   def perform
     dir = ASP::Server.get_all_files!
 

--- a/app/jobs/prepare_payment_requests_job.rb
+++ b/app/jobs/prepare_payment_requests_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class PreparePaymentRequestsJob < ApplicationJob
-  queue_as :default
+  queue_as :payments
 
   def perform
     ASP::PaymentRequest

--- a/app/jobs/send_payment_requests_job.rb
+++ b/app/jobs/send_payment_requests_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SendPaymentRequestsJob < ApplicationJob
-  queue_as :default
+  queue_as :payments
 
   sidekiq_options retry: false
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,15 @@ services:
       - "./:/app"
       - "/app/node_modules"
     entrypoint: ''
+  worker-payments:
+    image: aplypro
+    env_file:
+      - '.env.local'
+    command: ["bundle", "exec", "sidekiq", "--queue", "payments"]
+    volumes:
+      - "./:/app"
+      - "/app/node_modules"
+    entrypoint: ''
   db:
     # Scalingo only goes up to 14
     image: postgres:14


### PR DESCRIPTION
The payment tasks are quite heavy: sending requires validating 7000+ records with an XSD schema, updating the associated records, and parsing the results alos means downloading big files which results in big downloads + updating up to 100K records (and going through big XML files again).

To avoid getting OOM-killed by Scalingo (which happens in a dedicated container or in a worker), spawn a new worker to clearly handle that side of the product, and we can beef up the specs when it's running in Scalingo, at least for the time being where we deal with huge volumes.