### PR TITLE
jobs: don't retry the PollPaymentsServerJob for now

### DIFF
--- a/app/jobs/poll_payments_server_job.rb
+++ b/app/jobs/poll_payments_server_job.rb
@@ -3,6 +3,8 @@
 class PollPaymentsServerJob < ApplicationJob
   queue_as :payments
 
+  sidekiq_options retry: false
+
   def perform
     dir = ASP::Server.get_all_files!
 


### PR DESCRIPTION
We're too early-stage to confidently and immediately retry this job until it works. If it's failed once there is little chance it will succeed a minute or an hour later.

We might reconsider in the future but just because this job is meant to be run daily doesn't mean we want the whole
auto-retry-exponential-backoff baked in.