### PR TITLE
Fix/dont double raise unmatchedresponsefile

### DIFF
--- a/app/services/asp/file_handler.rb
+++ b/app/services/asp/file_handler.rb
@@ -28,6 +28,8 @@ module ASP
 
     def file_saved?
       target_attachment.attached?
+    rescue UnmatchedResponseFile
+      false
     end
 
     private

--- a/spec/jobs/poll_payments_server_job_spec.rb
+++ b/spec/jobs/poll_payments_server_job_spec.rb
@@ -6,23 +6,21 @@ RSpec.describe PollPaymentsServerJob do
   include ActiveJob::TestHelper
 
   let(:server_double) { class_double(ASP::Server) }
-  let(:reader_double) { class_double(ASP::FileHandler) }
-  let(:double) { instance_double(ASP::FileHandler) }
+  let(:handler_double) { instance_double(ASP::FileHandler) }
   let(:mock_file) { Tempfile.create }
   let(:basename) { File.basename(mock_file) }
 
   before do
     stub_const("ASP::Server", server_double)
-    stub_const("ASP::FileHandler", reader_double)
+    stub_const("ASP::FileHandler", class_double(ASP::FileHandler, new: handler_double))
 
     allow(Dir).to receive(:each_child).and_yield(basename)
 
     allow(server_double).to receive(:get_all_files!).and_return(File.dirname(mock_file))
     allow(server_double).to receive(:remove_file!)
 
-    allow(reader_double).to receive(:new).and_return double
-    allow(double).to receive(:parse!)
-    allow(double).to receive(:file_saved?)
+    allow(handler_double).to receive(:parse!)
+    allow(handler_double).to receive(:file_saved?)
   end
 
   it "calls the get_all_files! ASP::Server method" do
@@ -34,11 +32,11 @@ RSpec.describe PollPaymentsServerJob do
   it "feeds each file to an ASP::FileHandler" do
     perform_enqueued_jobs { described_class.perform_later }
 
-    expect(double).to have_received(:parse!)
+    expect(handler_double).to have_received(:parse!)
   end
 
   context "when the reader manages to save the file" do
-    before { allow(double).to receive(:file_saved?).and_return true }
+    before { allow(handler_double).to receive(:file_saved?).and_return true }
 
     it "deletes it on the server" do
       perform_enqueued_jobs { described_class.perform_later }
@@ -49,7 +47,7 @@ RSpec.describe PollPaymentsServerJob do
 
   context "when the original request can't be found" do
     before do
-      allow(double).to receive(:parse!).and_raise ASP::Errors::UnmatchedResponseFile
+      allow(handler_double).to receive(:parse!).and_raise ASP::Errors::UnmatchedResponseFile
     end
 
     it "does not remove the file off the server" do
@@ -61,11 +59,11 @@ RSpec.describe PollPaymentsServerJob do
 
   context "when the request can't be processed" do
     before do
-      allow(double).to receive(:parse!).and_raise ASP::Errors::ResponseFileParsingError
+      allow(handler_double).to receive(:parse!).and_raise ASP::Errors::ResponseFileParsingError
     end
 
     context "when the file has been attached" do
-      before { allow(double).to receive(:file_saved?).and_return true }
+      before { allow(handler_double).to receive(:file_saved?).and_return true }
 
       it "deletes it on the server" do
         perform_enqueued_jobs { described_class.perform_later }
@@ -75,7 +73,7 @@ RSpec.describe PollPaymentsServerJob do
     end
 
     context "when the file has not been attached" do
-      before { allow(double).to receive(:file_saved?).and_return false }
+      before { allow(handler_double).to receive(:file_saved?).and_return false }
 
       it "doesn't delete it on the server" do
         perform_enqueued_jobs { described_class.perform_later }


### PR DESCRIPTION
du dernier commit:

```
There's a strange logic path in the ASP file removal, because we only
try to remove the file if we've successfully saved it on our side,
even if the processing goes wrong (ResponseFileParsingError): if the
file is safe with us there's no need to keep it on the ASP servers.

The problem is that `handler.file_saved?` was also triggering the
error, making this code crash:

      begin
        handler.parse!
      rescue ASP::Errors::ResponseFileParsingError, ASP::Errors::UnmatchedResponseFile => e
        Sentry.capture_exception(e)
      ensure
        ASP::Server.remove_file!(filename: filename) if handler.file_saved?
      end

In the case of an unmatched file (i.e we can't find the associated
ASP::Request, for payment files we're always good), the `parse!` code
will raise (persist_file! -> target_attachment-> record ->
find_record! -> UnmatchedResponseFile).

This goes to the rescue block where we tell Sentry about it, and then
the ensure block will try to remove the file if we've saved it. But
`file_saved?` is calling `target_attachment` too, which will trigger
the error again, but this time uncaught.

Solve this by simply making sure `file_saved?` always does it job by
gracefully replying no (which is the correct answer) if the file
wasn't even matched.
```