### PR TITLE
scalingo: try and use better worker names

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -v
-workerdoc: bundle exec sidekiq --queue documents
-payments: bundle exec sidekiq --queue payments
+worker-documents: bundle exec sidekiq --queue documents
+worker-payments: bundle exec sidekiq --queue payments
 postdeploy: bundle exec rails db:prepare


### PR DESCRIPTION
This should fail because we're not allowed a dash in the names but sometimes you gotta give it a try anyway