### PR TITLE
pfmps: ensure a locked PFMP cannot be destroyed

### DIFF
--- a/app/controllers/pfmps_controller.rb
+++ b/app/controllers/pfmps_controller.rb
@@ -56,10 +56,13 @@ class PfmpsController < ApplicationController
   end
 
   def destroy
-    @pfmp.destroy
-
-    redirect_to class_student_path(@classe, @schooling.student),
-                notice: t("flash.pfmps.destroyed", name: @schooling.student.full_name)
+    if @pfmp.destroy
+      redirect_to class_student_path(@classe, @schooling.student),
+                  notice: t("flash.pfmps.destroyed", name: @schooling.student.full_name)
+    else
+      redirect_to class_student_path(@classe, @schooling.student),
+                  alert: t("flash.pfmps.not_destroyed")
+    end
   end
 
   private

--- a/app/models/pfmp.rb
+++ b/app/models/pfmp.rb
@@ -44,6 +44,8 @@ class Pfmp < ApplicationRecord
 
   delegate :wage, to: :mef
 
+  before_destroy :ensure_unlocked?, prepend: true
+
   def self.perfect
     joins(:student)
       .merge(Schooling.student)
@@ -121,6 +123,15 @@ class Pfmp < ApplicationRecord
   def duplicates
     student.pfmps.excluding(self).select do |other|
       other.start_date == start_date && other.end_date == end_date
+    end
+  end
+
+  def ensure_unlocked?
+    # using `return unless locked?` is awkward
+    if locked? # rubocop:disable Style/GuardClause
+      errors.add(:base, :locked)
+
+      throw :abort
     end
   end
 end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -9,6 +9,7 @@ fr:
       not_authorised_to_validate: Seuls les personnels de direction peuvent valider les PFMPs
       not_authorised_to_invite: Seuls les personnels de direction peuvent gérer les accès
       destroyed: La PFMP de %{name} a bien été supprimée
+      not_destroyed: La PFMP ne peut pas être supprimée car son paiement est en cours de traitement
       validated: La PFMP de %{name} a bien été validée
       create_payment_request: Une nouvelle demande de paiement a été créée
     ribs:

--- a/spec/models/pfmp_spec.rb
+++ b/spec/models/pfmp_spec.rb
@@ -75,6 +75,16 @@ RSpec.describe Pfmp do
     end
   end
 
+  describe "deletion" do
+    context "when there is an ongoing payment request" do
+      let(:pfmp) { create(:asp_payment_request, :sent).pfmp }
+
+      it "cannot be deleted" do
+        expect { pfmp.destroy! }.to raise_error ActiveRecord::RecordNotDestroyed
+      end
+    end
+  end
+
   describe "states" do
     it "is initially pending" do
       expect(pfmp).to be_in_state :pending


### PR DESCRIPTION
Disabling the actions on the frontend only goes so far – and we have some reports of people somehow deleting locked PFMPs so add the check where it belongs.