### PR TITLE
asp: make the readers implement Enumerable

### DIFF
--- a/app/services/asp/readers/base.rb
+++ b/app/services/asp/readers/base.rb
@@ -3,6 +3,8 @@
 module ASP
   module Readers
     class Base
+      include Enumerable
+
       attr_reader :io, :record
 
       def initialize(io:, record: nil)

--- a/app/services/asp/readers/csv_reader.rb
+++ b/app/services/asp/readers/csv_reader.rb
@@ -3,14 +3,24 @@
 module ASP
   module Readers
     class CSVReader < Base
+      attr_reader :csv
+
       ASP_CSV_OPTIONS = {
         headers: true,
         col_sep: ";",
         encoding: "ISO8859-1"
       }.freeze
 
+      delegate :each, to: :csv
+
+      def initialize(io:, record: nil)
+        super
+
+        @csv ||= CSV.parse(io, **parsing_options)
+      end
+
       def process!
-        CSV.parse(io, **parsing_options) do |row|
+        each do |row|
           ASP::PaymentRequest
             .find(request_identifier(row))
             .tap { |request| handle_request(request, row) }


### PR DESCRIPTION
It comes in handy to use the logic of the readers without necessarily processing them (i.e trying to update/persist some request changes). You might want to inspect an integrations/rejects/payments file without having to download it and look at the raw string, which is the only option at the moment since `process!` is the only entrypoint.

Change this around by having all readers include Enumerable, which is delegated to the underlying "store" which happens to be a CSV object for the integrations/rejects file, or a Nokogiri XML object if we're looking at the payments.

This means they all inherit the Enumerable API which now allows us to go:

```
reader = ASP::Readers::IntegrationsFileReader.new("some file content")

reader.find { |r| r["idIndDoss"] > 1000 } # a strange but valid query
reader.count
reader.map {  |r| puts "looking at line with request ID: #{r.fields.first}" }
```

For the payments file I went a step further by creating a small wrapping class for each node in the
XML (ASP::Readers::PaymentsFileReader::Node), that encapsulate some of the node-specific logic. Which in turn allows things like:

```
reader = ASP::Readers::PaymentsFileReader.new("some file content")

reader.map { |n| n.state }.uniq
=> ["INVALIDE"]

reader.count
reader.each { |node| puts "looking at #{node.asp_prestation_dossier_id}" }
```

That's a lot of freebies for 50 lines of code (10 without the Node class) and it should make introspection a lot easier.