### PR TITLE
asp: allow inspecting the request files

### DIFF
--- a/app/models/asp/request.rb
+++ b/app/models/asp/request.rb
@@ -105,6 +105,12 @@ module ASP
       end
     end
 
+    def sent_ids
+      Nokogiri::XML(file.download)
+              .search("ENREGISTREMENT")
+              .pluck("idEnregistrement")
+    end
+
     private
 
     def results_attached?

--- a/app/models/asp/request.rb
+++ b/app/models/asp/request.rb
@@ -87,6 +87,24 @@ module ASP
       )
     end
 
+    def inspect_file(type)
+      attachment = send "#{type}_file"
+
+      raise ArgumentError, "there is no #{type} file on this request" unless attachment.attached?
+
+      klass = "ASP::Readers::#{type.capitalize}FileReader".constantize
+
+      klass
+        .new(io: attachment.download)
+        .tap do |reader|
+        reader.instance_eval do |obj|
+          def obj.process!
+            raise ASP::Readers::Errors::ReadOnlyMode
+          end
+        end
+      end
+    end
+
     private
 
     def results_attached?

--- a/app/services/asp/readers/errors.rb
+++ b/app/services/asp/readers/errors.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module ASP
+  module Readers
+    module Errors
+      class Error < StandardError; end
+      class ReadOnlyMode < Error; end
+    end
+  end
+end


### PR DESCRIPTION
This gives the API:

```ruby
request = ASP::Request.last

reader = request.inspect_file(:rejects)

reader.count # number of rows
ids = reader.map { |row| row.fields.first } # all request IDs in the file
reader.process! # -> ASP::Readers::Errors::ReadOnlyMode
```