### PR TITLE
spec: use real MEFs instead of generating wageless mefs

### DIFF
--- a/spec/factories/classes.rb
+++ b/spec/factories/classes.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :classe do
     establishment factory: %i[establishment with_fim_user]
 
-    mef
+    mef { Mef.take }
     sequence(:label) { |n| "2NDE#{n}" }
     start_year { 2023 }
 

--- a/spec/models/concerns/pfmp_amount_calculator_spec.rb
+++ b/spec/models/concerns/pfmp_amount_calculator_spec.rb
@@ -63,7 +63,10 @@ describe PfmpAmountCalculator do
       before { previous.update!(schooling: schooling) }
 
       context "with the same MEF" do
-        before { schooling.classe.update!(mef: mef) }
+        before do
+          schooling.classe.update!(mef: mef)
+          PfmpManager.new(previous).recalculate_amounts!
+        end
 
         it_calculates "a limited amount", 2
 
@@ -80,7 +83,10 @@ describe PfmpAmountCalculator do
     end
 
     context "with that schooling" do
-      before { previous.update!(schooling: pfmp.schooling) }
+      before do
+        previous.update!(schooling: pfmp.schooling)
+        PfmpManager.new(previous).recalculate_amounts!
+      end
 
       it_calculates "a limited amount", 2
     end


### PR DESCRIPTION
And fix the corresponding spec which were relying on an imaginary mef whose factory hardcodes a daily_rate of 1, hence why it "just worked" without updating the amount before.