### PR TITLE
db: fix the RIB type migration

### DIFF
--- a/db/migrate/20240503100542_add_type_on_rib.rb
+++ b/db/migrate/20240503100542_add_type_on_rib.rb
@@ -9,7 +9,7 @@ class AddTypeOnRib < ActiveRecord::Migration[7.1]
     # `other_person`. See commit.
     add_column :ribs, :owner_type, :integer, default: 1
 
-    Rib.where(personal: true).update(owner_type: :personal)
+    Rib.where(personal: true).update_all(owner_type: :personal) # rubocop:disable Rails/SkipsModelValidations
 
     change_column_null :ribs, :owner_type, false
 


### PR DESCRIPTION
`update` instantiates the model(s) and runs validations, which is bad for two reasons: 1. wildly inefficient as we have thousands of RIBs to update, 2. it will run into the readonly? protection we have on RIBs with active payment requests.