### PR TITLE
db: add indices on ASP attributes

### DIFF
--- a/db/migrate/20240506155825_add_indices_on_asp_attributes.rb
+++ b/db/migrate/20240506155825_add_indices_on_asp_attributes.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndicesOnASPAttributes < ActiveRecord::Migration[7.1]
+  def change
+    add_index :students, :asp_individu_id, unique: true
+    add_index :schoolings, :asp_dossier_id, unique: true
+    add_index :pfmps, :asp_prestation_dossier_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_03_100542) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_06_155825) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -187,6 +187,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_03_100542) do
     t.bigint "schooling_id", null: false
     t.string "asp_prestation_dossier_id"
     t.integer "amount"
+    t.index ["asp_prestation_dossier_id"], name: "index_pfmps_on_asp_prestation_dossier_id", unique: true
     t.index ["schooling_id"], name: "index_pfmps_on_schooling_id"
   end
 
@@ -216,6 +217,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_03_100542) do
     t.string "administrative_number"
     t.integer "status"
     t.index ["administrative_number"], name: "index_schoolings_on_administrative_number", unique: true
+    t.index ["asp_dossier_id"], name: "index_schoolings_on_asp_dossier_id", unique: true
     t.index ["classe_id"], name: "index_schoolings_on_classe_id"
     t.index ["student_id", "classe_id"], name: "one_schooling_per_class_student", unique: true
     t.index ["student_id"], name: "index_schoolings_on_student_id"
@@ -242,6 +244,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_03_100542) do
     t.string "asp_individu_id"
     t.boolean "ine_not_found", default: false, null: false
     t.index ["asp_file_reference"], name: "index_students_on_asp_file_reference", unique: true
+    t.index ["asp_individu_id"], name: "index_students_on_asp_individu_id", unique: true
     t.index ["ine"], name: "index_students_on_ine", unique: true
   end
 


### PR DESCRIPTION
I don't understand why it wasn't done in the first place when we added them but this will

1. ensure integrity because they actually all need to be unique in their scope;

2. hopefully provide a solid performance boost especially in the payments-parsing job which reads thousands of XML records and uses `asp_prestation_dossier_id` to locate the matching record in our database. Right now there is no index so it probably does a full-table scans for each record which is bad. We're swapping hard and getting OOMK on the latest file.

c.f [1]: bc3ba1b4aacfed537a5f4556861ba5bbaf8ecaf5