### PR TITLE
scalingo: remove redundant install of libyaml-dev

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,3 +1,2 @@
-https://github.com/Scalingo/apt-buildpack.git
 https://github.com/Scalingo/nodejs-buildpack.git
 https://github.com/Scalingo/ruby-buildpack.git

--- a/Aptfile
+++ b/Aptfile
@@ -1,1 +1,0 @@
-libyaml-dev


### PR DESCRIPTION
From the latest deploy logs:

```
=====> Detected Framework: Apt
-----> Reusing cache
-----> Updating apt caches
       Hit:1 http://archive.ubuntu.com/ubuntu jammy InRelease
       Get:2 http://archive.ubuntu.com/ubuntu jammy-updates InRelease [119 kB]
       Hit:3 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
       Get:4 http://security.ubuntu.com/ubuntu jammy-security InRelease [110 kB]
       Get:5 http://security.ubuntu.com/ubuntu jammy-security/main amd64 Packages [1757 kB]
       Fetched 1986 kB in 1s (1785 kB/s)
       Reading package lists...
-----> Fetching .debs for libyaml-dev
       Reading package lists...
       Building dependency tree...
       0 upgraded, 0 newly installed, 1 reinstalled, 0 to remove and 7 not upgraded.
       Need to get 0 B/62.8 kB of archives.
       After this operation, 0 B of additional disk space will be used.
       Download complete and in download only mode
-----> Installing libyaml-dev_0.2.2-1build2_amd64.deb
-----> Writing profile script
-----> Rewrite package-config files
```

So the package is back in the buildpack and we don't need that step anymore.