### PR TITLE
spec: don't freak out Guard

### DIFF
--- a/spec/factories/asp/payment_requests.rb
+++ b/spec/factories/asp/payment_requests.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "./mock/factories/asp"
-
 FactoryBot.define do
   factory :asp_payment_request, class: "ASP::PaymentRequest" do
     initialize_with { pfmp.payment_requests.last } # FIXME


### PR DESCRIPTION
If we require the file manually on top of the auto-reload (I assume) of the app it causes the code to crash with:

     KeyError:
       Factory not registered: "asp_reject"

Remove the manual require (they ASP factories are automatically loaded in the rails_helper.rb file) and everything is nice again. If you need to use the specs in dev (creating fake data, etc), then load the ASP factories in your console.

Worst come to worse, you can always include:

require "./mock/factories/asp"

at the top of config/environments/development.rb and have it loaded in your normal console at all times.