### PR TITLE
jobs: run some of the payments job in a single-threaded queue

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -v
 workerdocuments: bundle exec sidekiq --queue documents
-workerpayments: bundle exec sidekiq --queue payments
+workerpayments: bundle exec sidekiq --queue payments,payments_serial
 postdeploy: bundle exec rails db:prepare

--- a/app/jobs/process_asp_response_file_job.rb
+++ b/app/jobs/process_asp_response_file_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProcessASPResponseFileJob < ApplicationJob
-  queue_as :payments
+  queue_as :payments_serial
 
   def perform(raw_filename)
     filename = ASP::Filename.new(raw_filename)

--- a/app/jobs/send_payment_requests_job.rb
+++ b/app/jobs/send_payment_requests_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SendPaymentRequestsJob < ApplicationJob
-  queue_as :payments
+  queue_as :payments_serial
 
   sidekiq_options retry: false
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+Sidekiq.configure_server do |config|
+  config.capsule("single-threaded") do |cap|
+    cap.concurrency = 1
+    cap.queues = %w[payments_serial]
+  end
+end


### PR DESCRIPTION
ProcessASPResponseFileJob can't really run concurrently: it always triggers a bunch of updates on the asp_payment_requests.transitions which means PG deadlocks in production.

SendPaymentRequestsJob is also dangerous even though it is already wrapped in a transaction: there's a stack of ready-payment-requests and it needs to be unstacked progressively, not concurrently.

Closes #870.