### PR TITLE
jobs: don't raise an error if there are no payment requests ready

### DIFF
--- a/app/jobs/send_payment_requests_job.rb
+++ b/app/jobs/send_payment_requests_job.rb
@@ -8,6 +8,8 @@ class SendPaymentRequestsJob < ApplicationJob
   def perform
     payment_requests = ASP::PaymentRequest.in_state(:ready)
 
+    return if payment_requests.none?
+
     limit = [
       payment_requests.count,
       ASP::Request.total_payment_requests_left,

--- a/spec/jobs/send_payment_requests_job_spec.rb
+++ b/spec/jobs/send_payment_requests_job_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe SendPaymentRequestsJob do
     create_list(:asp_payment_request, 5, :ready)
   end
 
+  context "when there are no payment requests ready" do
+    before { ASP::PaymentRequest.destroy_all }
+
+    it "does not run" do
+      expect { described_class.perform_now }.not_to raise_error ASP::Errors::MaxRecordsPerWeekLimitReached
+    end
+  end
+
   context "when asked to send more than the allowed amount per request" do
     before { stub_const("ASP::Request::MAX_RECORDS_PER_FILE", 3) }
 


### PR DESCRIPTION
a final number (post-limiting) of 0 payment requests was interpreted by the

    raise ASP::Errors::MaxRecordsPerWeekLimitReached if limit.zero?

line, which is valid if you did have payment requests in the first place (and we can't honour it because you've reached the limit), but if you had no payment requests in the first place that's not the case.