### PR TITLE
jobs: don't use the capsule feature

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -v
 workerdocuments: bundle exec sidekiq --queue documents
-workerpayments: bundle exec sidekiq --queue payments,payments_serial
+workerpayments: bundle exec sidekiq --queue payments --concurrency=1
 postdeploy: bundle exec rails db:prepare

--- a/app/jobs/prepare_payment_request_job.rb
+++ b/app/jobs/prepare_payment_request_job.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class PreparePaymentRequestJob < ApplicationJob
-  queue_as :payments
-
   sidekiq_options retry: false
 
   retry_on Faraday::UnauthorizedError, wait: 1.second, attempts: 10

--- a/app/jobs/process_asp_response_file_job.rb
+++ b/app/jobs/process_asp_response_file_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ProcessASPResponseFileJob < ApplicationJob
-  queue_as :payments_serial
+  queue_as :payments
 
   def perform(raw_filename)
     filename = ASP::Filename.new(raw_filename)

--- a/app/jobs/send_payment_requests_job.rb
+++ b/app/jobs/send_payment_requests_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SendPaymentRequestsJob < ApplicationJob
-  queue_as :payments_serial
+  queue_as :payments
 
   sidekiq_options retry: false
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-Sidekiq.configure_server do |config|
-  config.capsule("single-threaded") do |cap|
-    cap.concurrency = 1
-    cap.queues = %w[payments_serial]
-  end
-end

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aplypro
-  VERSION = "1.17"
+  VERSION = "1.17.1"
 end


### PR DESCRIPTION
Our sidekiq initializer says "use the single-threaded capsule for the payments_serial queue" but that capsule is used for all workers, and it doesn't seem to care about the -q argument passed to each worke process.

Remove it in the meantime and just disable concurrency (with n=1) on the payments worker, which kinda makes sense because it handles big, unfrequent jobs that are all to do with sending or receiving files from the ASP. We could potentially rename it to asp-worker to make that clearer.

As part of that logic, move the PreparePaymentRequestJob to the normal worker because like the other jobs there it does some API-querying and operates on our app only.