### PR TITLE
Feat/csv import

### DIFF
--- a/app/models/schooling.rb
+++ b/app/models/schooling.rb
@@ -25,7 +25,7 @@ class Schooling < ApplicationRecord
   # https://github.com/betagouv/aplypro/issues/792
   scope :with_one_character_attributive_decision_version, -> { where("schoolings.attributive_decision_version < 10") }
 
-  validates :student, uniqueness: { scope: :end_date }, if: :open?
+  validates :student, uniqueness: { scope: :end_date, message: :unique_active_schooling }, if: :open?
   validates :student, uniqueness: { scope: :classe }, if: :closed?
 
   def generate_administrative_number

--- a/app/models/student/mappers/base.rb
+++ b/app/models/student/mappers/base.rb
@@ -80,7 +80,7 @@ class Student
       def map_student!(attrs)
         attributes = map_student_attributes(attrs)
 
-        return if attributes[:ine].nil?
+        return if attributes[:ine].blank?
 
         Student
           .find_or_initialize_by(ine: attributes[:ine])

--- a/app/models/student/mappers/csv.rb
+++ b/app/models/student/mappers/csv.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+class Student
+  module Mappers
+    class CSV < Base
+      class StudentMapper < Dry::Transformer::Pipe
+        import Dry::Transformer::HashTransformations
+
+        define! do
+          symbolize_keys
+
+          rename_keys(
+            :prénom => :last_name,
+            :nom => :first_name,
+            :date_naissance => :birthdate,
+            :"Sexe biologique" => :biological_sex,
+            :"Code INSEE de ville de naissance" => :birthplace_city_insee_code,
+            :"Code INSEE de pays de naissance" => :birthplace_country_insee_code,
+            :"Code postal de résidence" => :address_postal_code,
+            :"Code INSEE de ville de résidence" => :address_city_insee_code,
+            :"Code INSEE de pays de résidence" => :address_country_code
+          )
+
+          map_value :biological_sex, lambda { |x|
+            case x
+            when "f"
+              :female
+            when "h"
+              :male
+            else
+              raise ArgumentError, "could not understand a value of '#{x}' for biological_sex"
+            end
+          }
+
+          accept_keys(Student.attribute_names.map(&:to_sym))
+        end
+      end
+
+      class ClasseMapper < Dry::Transformer::Pipe
+        import Dry::Transformer::HashTransformations
+
+        define! do
+          deep_symbolize_keys
+
+          rename_keys(label_classe: :label)
+
+          accept_keys %i[label mef_code]
+        end
+      end
+
+      def map_schooling!(classe, student, entry)
+        schooling = Schooling.find_or_initialize_by(classe: classe, student: student) do |sc|
+          sc.start_date = entry["date_début"]
+          sc.end_date = entry["date_fin"]
+        end
+
+        student.close_current_schooling! if schooling.open? && schooling != student.current_schooling
+
+        schooling.save!
+      end
+    end
+  end
+end

--- a/app/models/student/mappers/sygne.rb
+++ b/app/models/student/mappers/sygne.rb
@@ -3,13 +3,6 @@
 class Student
   module Mappers
     class Sygne < Base
-      STUDENT_MAPPING = {
-        ine: "ine",
-        first_name: "prenom",
-        last_name: "nom",
-        birthdate: "dateNaissance"
-      }.freeze
-
       class StudentMapper < Dry::Transformer::Pipe
         import Dry::Transformer::HashTransformations
 

--- a/app/services/csv_importer.rb
+++ b/app/services/csv_importer.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class CSVImporter
+  module Errors
+    class Error < StandardError; end
+    class WrongHeaders < Error; end
+  end
+
+  HEADERS = [
+    "ine",
+    "prénom",
+    "nom",
+    "date_naissance",
+    "label_classe",
+    "mef_code",
+    "année_scolaire",
+    "date_début",
+    "date_fin",
+    "Sexe biologique",
+    "Code INSEE de ville de naissance",
+    "Code INSEE de pays de naissance",
+    "Code postal de résidence",
+    "Code INSEE de ville de résidence",
+    "Code INSEE de pays de résidence"
+  ].freeze
+
+  attr_reader :data, :uai
+
+  def initialize(io, uai)
+    @data = CSV.parse(io, col_sep: ";", headers: true)
+    @uai = uai
+
+    difference = data.headers.difference(HEADERS)
+
+    raise Errors::WrongHeaders, "headers mismatch: #{difference}" if difference.any?
+  end
+
+  def parse!
+    Student::Mappers::CSV.new(data, uai).parse!
+  end
+end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -42,6 +42,10 @@ fr:
   activerecord:
     errors:
       models:
+        schooling:
+          attributes:
+            student:
+              unique_active_schooling: "a déjà une scolarité active"
         invitation:
           attributes:
             email:

--- a/lib/tasks/students.rake
+++ b/lib/tasks/students.rake
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require "csv"
+
+namespace :students do
+  task :csv_import, %i[filepath uai] => :environment do |_t, args|
+    filepath = args[:filepath]
+    uai = args[:uai]
+
+    puts "Going to import for UAI #{uai} with CSV at #{filepath}..."
+
+    data = File.read(filepath)
+
+    CSVImporter.new(data, uai).parse!
+  end
+end

--- a/spec/models/student/mappers/csv_spec.rb
+++ b/spec/models/student/mappers/csv_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "./mock/factories/api_student"
+require "./spec/support/shared/student_mapper"
+
+describe Student::Mappers::CSV do
+  subject(:mapper) { described_class }
+
+  let(:establishment) { create(:establishment) }
+  let(:uai) { establishment.uai }
+  let(:fixture) { Rails.root.join("spec/services/csv_importer_fixture.csv").read }
+
+  it_behaves_like "a student mapper" do
+    let(:normal_payload) { CSV.parse(fixture, col_sep: ";", headers: true) }
+    let(:nil_ine_payload) { normal_payload.tap { |payload| payload.first["ine"] = "" } }
+    let(:irrelevant_mefs_payload) { normal_payload.tap { |payload| payload.first["mef_code"] = "ABC" } }
+    let(:faulty_student_payload) { normal_payload.tap { |payload| payload.delete("mef_code") } }
+    let(:faulty_classe_payload) { normal_payload.tap { |payload| payload.delete("classe_label") } }
+  end
+end

--- a/spec/services/csv_importer_fixture.csv
+++ b/spec/services/csv_importer_fixture.csv
@@ -1,0 +1,2 @@
+ine;prénom;nom;date_naissance;label_classe;mef_code;année_scolaire;date_début;date_fin;Sexe biologique;Code INSEE de ville de naissance;Code INSEE de pays de naissance;Code postal de résidence;Code INSEE de ville de résidence;Code INSEE de pays de résidence
+ABCDEF034;MARIE;CURIE;12/03/2006;BAC PRO CHIMIE : 1ERE PRO;2473000432;2023;28/06/2023;;f;56162;99100;29570;29238;99100

--- a/spec/services/csv_importer_spec.rb
+++ b/spec/services/csv_importer_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe CSVImporter do
+  subject(:importer) { described_class.new(fixture, establishment.uai) }
+
+  let(:fixture) { File.read(File.join(__dir__, "csv_importer_fixture.csv")) }
+  let(:establishment) { create(:establishment) }
+
+  before do
+    double = instance_double(Student::Mappers::CSV)
+
+    stub_const("Student::Mappers::CSV", class_double(Student::Mappers::CSV, new: double))
+
+    allow(double).to receive(:parse!).and_return :result
+  end
+
+  context "when then headers are in an unexpected shape" do
+    let(:fixture) { "foo,bar\nbat,man" }
+
+    it "raises an error" do
+      expect { importer.parse! }.to raise_error described_class::Errors::WrongHeaders
+    end
+  end
+
+  it "calls the mapper with the right arguments" do
+    expect(importer.parse!).to eq :result
+  end
+end


### PR DESCRIPTION
Pour #515.

Finalement il suffisait simplement de rajouter un `Student::Mappers::CSV` à ceux existants, ce qui nous offre une interface déjà bien testée qui se charge de vérifier les MEFs et de faire les upserts des élèves à importer.

Utilisation : 

```sh
./bin/rails students:csv_import["chemin/vers/fichier.csv", "0024123"]
```

importe le contenu du fichier `chemin/vers/fichier.csv` au compte de l'établissement avec l'UAI `0024123`.