### PR TITLE
asp: move out the RIB name sanitisation

### DIFF
--- a/app/services/asp/mappers/coord_paie_mapper.rb
+++ b/app/services/asp/mappers/coord_paie_mapper.rb
@@ -10,14 +10,6 @@ module ASP
         CREDIT_MUTUEL_ARKEA: "CMBRFR2BARK"
       }.freeze
 
-      ALLOWED_CHARACTERS = %w[/ - ? : ( ) . , '].freeze
-      RIB_NAME_MASK = /\A[\s[[:alnum:]]#{ALLOWED_CHARACTERS.map { |c| Regexp.escape(c) }.join}]+\z/
-
-      SOFT_HYPHEN = "­" # this invisible thing is not a space and deserves its own variable, see git blame
-
-      SUBSTITUTE_WITH_SPACE_CHARACTERS = %w[; - ´].push(SOFT_HYPHEN).freeze
-      SUBSTITUTE_NOSPACE_CHARACTERS = %w[& _ ^].freeze
-
       MAPPING = {
         bic: :bic
       }.freeze
@@ -46,17 +38,7 @@ module ASP
       end
 
       def intitdest
-        rib.name
-           .chars
-           .map { |c| c.in?(SUBSTITUTE_WITH_SPACE_CHARACTERS) ? " " : c }
-           .reject { |c| c.in?(SUBSTITUTE_NOSPACE_CHARACTERS) }
-           .join
-           .squish
-           .tap do |value|
-          if !RIB_NAME_MASK.match?(value)
-            raise ArgumentError, "the RIB ##{rib.id} name is still invalid after sanitisation"
-          end
-        end
+        ASP::RibNameSanitiser.call(rib.name)
       end
 
       # @emaildoc

--- a/app/services/asp/rib_name_sanitiser.rb
+++ b/app/services/asp/rib_name_sanitiser.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module ASP
+  class RibNameSanitiser
+    DASH = "-"
+    APOSTROPHE = "'"
+    SPACE = " "
+    NOTHING = nil
+
+    SUBSTITUTION_MAP = {
+      DASH => %w[–],
+      APOSTROPHE => %w[´ ’],
+      SPACE => %w[;].push("­"), # soft-hypen, not a space
+      NOTHING => %w[^ >]
+    }.freeze
+
+    ALLOWED_CHARACTERS = %w[/ - ? : ( ) . , '].freeze
+    RIB_NAME_MASK = /\A[\s[[:alnum:]]#{ALLOWED_CHARACTERS.map { |c| Regexp.escape(c) }.join}]+\z/
+
+    def self.call(name)
+      new.call(name)
+    end
+
+    def call(name)
+      characters = name.chars
+
+      characters
+        .map { |char| substitute(char) }
+        .filter { |char| allowed?(char) }
+        .join
+        .squish
+    end
+
+    def substitute(char)
+      substitution = SUBSTITUTION_MAP.find { |_k, v| v.include?(char) }
+
+      if substitution.present?
+        substitution.first
+      else
+        char
+      end
+    end
+
+    def allowed?(char)
+      RIB_NAME_MASK.match?(char)
+    end
+  end
+end

--- a/spec/services/asp/mappers/coord_paie_mapper_spec.rb
+++ b/spec/services/asp/mappers/coord_paie_mapper_spec.rb
@@ -54,11 +54,13 @@ describe ASP::Mappers::CoordPaieMapper do
     end
   end
 
-  context "when the name has special characters in it" do
-    before { rib.update!(name: "Bonnie´ & _Clyde^;retraités-end") }
+  describe "intitdest" do
+    before do
+      allow(ASP::RibNameSanitiser).to receive(:call).with(rib.name).and_return :result
+    end
 
-    it "removes them" do
-      expect(mapper.intitdest).to eq "Bonnie Clyde retraités end"
+    it "returns the name processed by RibNameSanitiser" do
+      expect(mapper.intitdest).to eq :result
     end
   end
 

--- a/spec/services/asp/rib_name_sanitiser_spec.rb
+++ b/spec/services/asp/rib_name_sanitiser_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ASP::RibNameSanitiser do
+  subject(:result) { described_class.new.call(name) }
+
+  context "when the RIB has space-like characters" do
+    let(:name) { "O’Connell" }
+
+    it "substitutes them with a normal space" do
+      expect(result).to eq "O'Connell"
+    end
+  end
+
+  context "when the RIB has subsitutable characters" do
+    let(:name) { "O–Connell>>" }
+
+    it "replaces them" do
+      expect(result).to eq "O-Connell"
+    end
+  end
+
+  context "when the RIB has irrelevant characters" do
+    let(:name) { "FOO^BAR" }
+
+    it "deletes them" do
+      expect(result).to eq "FOOBAR"
+    end
+  end
+
+  context "when the RIB has extra spaces" do
+    let(:name) { "Some      long name" }
+
+    it "removes them" do
+      expect(result).to eq "Some long name"
+    end
+  end
+
+  context "when the RIB has unknown, invalid characters" do
+    let(:name) { "Johnny 🔥 Cash" }
+
+    it "removes them" do
+      expect(result).to eq "Johnny Cash"
+    end
+  end
+end


### PR DESCRIPTION
This tries and keeps best of both worlds by performing soft replacements for things we kinda-know-what-they-meant (dashes, apostrophes, etc) but also silently removes anything that's still offending the regexp at the end.

Closes #365.