### PR TITLE
stats: add an early version of a stats page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,11 @@ gem "nokogiri"
 # payments: XML exchange
 gem "net-sftp"
 
+# stats
+gem "chartkick"
+gem "groupdate"
+gem "scenic"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    chartkick (5.0.6)
     chronic (0.10.2)
     cmdparse (3.0.7)
     coderay (1.1.3)
@@ -202,6 +203,8 @@ GEM
     formatador (1.1.0)
     geom2d (0.4.1)
     globalid (1.2.1)
+      activesupport (>= 6.1)
+    groupdate (6.4.0)
       activesupport (>= 6.1)
     guard (2.18.1)
       formatador (>= 0.2.4)
@@ -482,6 +485,9 @@ GEM
     rubocop-rspec_rails (2.28.3)
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
+    scenic (1.8.0)
+      activerecord (>= 4.0.0)
+      railties (>= 4.0.0)
     sentry-rails (5.17.3)
       railties (>= 5.0)
       sentry-ruby (~> 5.17.3)
@@ -592,6 +598,7 @@ DEPENDENCIES
   bootsnap
   breadcrumbs_on_rails
   capybara
+  chartkick
   csv
   cucumber-rails
   database_cleaner-active_record
@@ -603,6 +610,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   faraday
+  groupdate
   guard
   guard-cucumber
   guard-rspec
@@ -626,6 +634,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   rubocop-rspec
+  scenic
   sentry-rails
   sentry-ruby
   shoulda-matchers

--- a/app/assets/stylesheets/misc.css
+++ b/app/assets/stylesheets/misc.css
@@ -90,3 +90,7 @@
   flex-direction: column;
   align-items: center;
 }
+
+.stat {
+  margin-bottom: 3rem;
+}

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class StatsController < ApplicationController
+  before_action :infer_page_title
+
+  skip_before_action :authenticate_user!
+
+  def index
+    @total_paid = PaidPfmp.paid.sum(:amount)
+    @total_paid_students = PaidPfmp.paid.distinct.count(:student_id)
+    @total_paid_pfmps = PaidPfmp.paid.count
+  end
+
+  def paid_pfmps_per_month
+    render json: PaidPfmp.group_by_month(:paid_at, format: "%B %Y").count
+  end
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails";
 import "controllers";
+import "chartkick";
+import "Chart.bundle";

--- a/app/models/paid_pfmp.rb
+++ b/app/models/paid_pfmp.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class PaidPfmp < ApplicationRecord
+  scope :paid, -> { where.not(paid_at: nil) }
+
+  def self.refresh
+    Scenic.database.refresh_materialized_view(table_name, concurrently: false, cascade: false)
+  end
+
+  def self.populated?
+    Scenic.database.populated?(table_name)
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -35,3 +35,4 @@
             %h1.fr-mb-5w= @page_title
         = yield
     = render 'shared/footer'
+    = render 'shared/shim'

--- a/app/views/shared/_shim.html
+++ b/app/views/shared/_shim.html
@@ -1,0 +1,1 @@
+<script async src="https://ga.jspm.io/npm:es-module-shims@1.10.0/dist/es-module-shims.js"></script>

--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -1,0 +1,20 @@
+
+.stat
+  %h2 Montant total payé
+  %span.fr-display--xl= number_to_currency(@total_paid)
+
+.stat
+  %h2 Nombre total d'élèves payés
+  %span.fr-display--xl= number_with_delimiter(@total_paid_students)
+
+.stat
+  %h2
+    Nombre total de
+    %acronym{title: "Période de formation en milieu professionnel"} PFMPs
+    payées
+  %span.fr-display--xl= number_with_delimiter(@total_paid_pfmps)
+
+.stat
+  %h2 Nombre de PFMPs payées par mois
+
+  = column_chart paid_pfmps_per_month_stats_path, label: "nombre de stages payés"

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -2,6 +2,9 @@
 
 # Pin npm packages by running ./bin/importmap
 
+pin "chartkick", to: "chartkick.js"
+pin "Chart.bundle", to: "Chart.bundle.js"
+
 pin "application", preload: true
 pin "@hotwired/turbo-rails", to: "turbo.min.js", preload: true
 pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true

--- a/config/initializers/chartkick.rb
+++ b/config/initializers/chartkick.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Chartkick.options = {
+  decimal: ",",
+  thousands: " "
+}

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -129,6 +129,8 @@ fr:
     faq: F.A.Q.
   pages:
     titles:
+      stats:
+        index: Statistiques
       users:
         select_establishment: Choix de l'établissement
       invitations:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -94,6 +94,12 @@ Rails.application.routes.draw do
   get "/legal", to: "home#legal"
   get "/faq", to: "home#faq"
 
+  resources :stats, only: [:index] do
+    collection do
+      get "paid_pfmps_per_month"
+    end
+  end
+
   if Rails.env.production?
     Sidekiq::Web.use(Rack::Auth::Basic) do |user, password|
       # https://github.com/sidekiq/sidekiq/wiki/Monitoring#rails-http-basic-auth-from-routes

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -30,3 +30,9 @@ end
 every :weekday, at: "7AM" do
   runner "PollPaymentsServerJob.perform_later"
 end
+
+# NOTE: refresh the materialized view that holds our paid requests
+# stats.
+every :weekday, at: "6AM" do
+  runner "PaidPfmp.refresh"
+end

--- a/cron.json
+++ b/cron.json
@@ -8,6 +8,9 @@
     },
     {
       "command": "0 7 * * 1-5 /bin/bash -l -c 'cd /app && bundle exec bin/rails runner -e production '\\''PollPaymentsServerJob.perform_later'\\'''"
+    },
+    {
+      "command": "0 6 * * 1-5 /bin/bash -l -c 'cd /app && bundle exec bin/rails runner -e production '\\''PaidPfmp.refresh'\\'''"
     }
   ]
 }

--- a/db/migrate/20240523061622_create_paid_pfmps.rb
+++ b/db/migrate/20240523061622_create_paid_pfmps.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CreatePaidPfmps < ActiveRecord::Migration[7.1]
+  def change
+    create_view :paid_pfmps, materialized: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_06_155825) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_23_061622) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -79,7 +79,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_06_155825) do
   end
 
   create_table "asp_users", force: :cascade do |t|
-    t.string "email", default: "", null: false
+    t.string "email", null: false
     t.string "name", null: false
     t.string "provider", null: false
     t.string "uid", null: false
@@ -300,4 +300,29 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_06_155825) do
   add_foreign_key "schoolings", "classes", column: "classe_id"
   add_foreign_key "schoolings", "students"
   add_foreign_key "users", "establishments", column: "selected_establishment_id"
+
+  create_view "paid_pfmps", materialized: true, sql_definition: <<-SQL
+      WITH paid_requests AS (
+           SELECT asp_payment_requests.pfmp_id,
+              most_recent_asp_payment_request_transition.created_at AS paid_at
+             FROM (asp_payment_requests
+               JOIN asp_payment_request_transitions most_recent_asp_payment_request_transition ON (((asp_payment_requests.id = most_recent_asp_payment_request_transition.asp_payment_request_id) AND (most_recent_asp_payment_request_transition.most_recent = true))))
+            WHERE (((most_recent_asp_payment_request_transition.to_state)::text = 'paid'::text) AND (most_recent_asp_payment_request_transition.to_state IS NOT NULL))
+          )
+   SELECT pfmps.id,
+      pfmps.start_date,
+      pfmps.end_date,
+      pfmps.created_at,
+      pfmps.updated_at,
+      pfmps.day_count,
+      pfmps.schooling_id,
+      pfmps.asp_prestation_dossier_id,
+      pfmps.amount,
+      schoolings.student_id,
+      paid_requests.paid_at
+     FROM ((pfmps
+       JOIN schoolings ON ((schoolings.id = pfmps.schooling_id)))
+       LEFT JOIN paid_requests ON ((paid_requests.pfmp_id = pfmps.id)))
+    WHERE (EXTRACT(isoyear FROM pfmps.end_date) = ANY (ARRAY['2023'::numeric, '2024'::numeric]));
+  SQL
 end

--- a/db/views/paid_pfmps_v01.sql
+++ b/db/views/paid_pfmps_v01.sql
@@ -1,0 +1,14 @@
+WITH paid_requests AS (
+  SELECT
+     asp_payment_requests.pfmp_id,
+     most_recent_asp_payment_request_transition.created_at AS paid_at
+  FROM asp_payment_requests
+  INNER JOIN asp_payment_request_transitions AS most_recent_asp_payment_request_transition ON asp_payment_requests.id = most_recent_asp_payment_request_transition.asp_payment_request_id AND most_recent_asp_payment_request_transition.most_recent = TRUE
+  WHERE (most_recent_asp_payment_request_transition.to_state IN ('paid')
+         AND most_recent_asp_payment_request_transition.to_state IS NOT NULL))
+SELECT
+  pfmps.*, schoolings.student_id, paid_at
+FROM pfmps
+INNER JOIN schoolings ON schoolings.id = pfmps.schooling_id
+LEFT OUTER JOIN paid_requests ON paid_requests.pfmp_id = pfmps.id
+WHERE EXTRACT(ISOYEAR FROM pfmps.end_date ) IN ('2023', '2024');


### PR DESCRIPTION
Une proposition de weekend de Pâques pour faire une page stats toute bête mais utile avec : 

- [`scenic`](https://github.com/scenic-views/scenic) pour stocker les chiffres intéressants sans casser la DB ;
- [`chartckick`](https://chartkick.com/) pour afficher des choses, mais pas forcément pertinent en vrai.

Le résultat avec un snapshot de prod : 

![image](https://github.com/betagouv/aplypro/assets/107635/33936321-79f9-4fce-b964-fd71b826bf27)


Bonus (et aussi motivation de base) : 

> Chaque service numérique du réseau beta.gouv.fr est tenu de mesurer son usage et son impact de manière publique sur une page "Stats". Cette mesure permet d'évaluer la pertinence de chaque service, et de vérifier qu'elle apporte réellement de la valeur à ses utilisateurs et utilisatrices. 

– https://beta.gouv.fr/stats/
