### PR TITLE
cron: move back the public stats generation

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -33,6 +33,6 @@ end
 
 # NOTE: refresh the materialized view that holds our paid requests
 # stats.
-every :weekday, at: "6AM" do
+every :weekday, at: "9AM" do
   runner "PaidPfmp.refresh"
 end

--- a/cron.json
+++ b/cron.json
@@ -10,7 +10,7 @@
       "command": "0 7 * * 1-5 /bin/bash -l -c 'cd /app && bundle exec bin/rails runner -e production '\\''PollPaymentsServerJob.perform_later'\\'''"
     },
     {
-      "command": "0 6 * * 1-5 /bin/bash -l -c 'cd /app && bundle exec bin/rails runner -e production '\\''PaidPfmp.refresh'\\'''"
+      "command": "0 9 * * 1-5 /bin/bash -l -c 'cd /app && bundle exec bin/rails runner -e production '\\''PaidPfmp.refresh'\\'''"
     }
   ]
 }


### PR DESCRIPTION
Since PollPaymentsServerJob runs at 7AM, it makes more sense to regenerate the stats at 9AM when all of the processing is (hopefully) done.