### PR TITLE
models: add a way to indicate udpatable attributes

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -3,7 +3,11 @@
 class ApplicationRecord < ActiveRecord::Base
   primary_abstract_class
 
-  def self.updatable_attributes
-    attribute_names.map(&:to_sym)
+  cattr_accessor :_updatable_attributes, default: []
+
+  class << self
+    def updatable_attributes(*args)
+      self._updatable_attributes += args
+    end
   end
 end

--- a/app/models/schooling.rb
+++ b/app/models/schooling.rb
@@ -28,6 +28,8 @@ class Schooling < ApplicationRecord
   validates :student, uniqueness: { scope: :end_date, message: :unique_active_schooling }, if: :open?
   validates :student, uniqueness: { scope: :classe }, if: :closed?
 
+  updatable_attributes :start_date, :end_date, :status
+
   def generate_administrative_number
     return if administrative_number.present?
 

--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -62,6 +62,16 @@ class Student < ApplicationRecord # rubocop:disable Metrics/ClassLength
     )
   }
 
+  updatable_attributes %i[
+    address_line1
+    address_postal_code
+    address_city_insee_code
+    address_country_code
+    birthplace_city_insee_code
+    birthplace_country_insee_code
+    biological_sex
+  ]
+
   # NOTE: used in stats for column "Données d'élèves nécessaires présentes"
   def self.asp_ready
     with_ine


### PR DESCRIPTION
Using attribute_names.map(&:to_sym) is slightly too general, it includes the `id` + timestamps (`created_at/updated_at`) which are internal to Rails and should probably never be updated.