### PR TITLE
docker: make sure we follow the same precision as `.ruby-version`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3-slim
+FROM ruby:3.3.1-slim
 
 EXPOSE 3000
 


### PR DESCRIPTION
`.ruby-version`: 3.3.1
`Dockerfile`: 3.3, which automatically gets 3.3.2 today, hence conflict.