### PR TITLE
Remove temporality of rebalancing

### DIFF
--- a/app/models/concerns/pfmp_amount_calculator.rb
+++ b/app/models/concerns/pfmp_amount_calculator.rb
@@ -13,28 +13,26 @@ module PfmpAmountCalculator
   end
 
   def previously_locked_amount
-    previous_pfmps
+    other_priced_pfmps
       .map(&:amount)
       .compact
       .sum
   end
 
-  def pfmps_for_mef_and_school_year
+  def other_pfmps
     student.pfmps
            .in_state(:completed, :validated)
            .joins(schooling: :classe)
            .where("classes.mef_id": mef.id, "classes.school_year_id": school_year.id)
   end
 
-  def previous_pfmps
-    pfmps_for_mef_and_school_year
-      .before(created_at)
+  def other_priced_pfmps
+    other_pfmps
       .where.not(amount: nil)
   end
 
-  def following_rebalancable_pfmps
-    pfmps_for_mef_and_school_year
-      .after(created_at)
+  def rebalancable_pfmps
+    other_pfmps
       .select(&:can_be_rebalanced?)
   end
 end

--- a/app/models/concerns/pfmp_amount_calculator.rb
+++ b/app/models/concerns/pfmp_amount_calculator.rb
@@ -20,11 +20,7 @@ module PfmpAmountCalculator
   end
 
   def other_pfmps_for_mef
-    student.pfmps
-           .in_state(:completed, :validated)
-           .joins(schooling: :classe)
-           .where("classes.mef_id": mef.id, "classes.school_year_id": school_year.id)
-           .excluding(self)
+    all_pfmps_for_mef.excluding(self)
   end
 
   def other_priced_pfmps
@@ -35,5 +31,12 @@ module PfmpAmountCalculator
   def rebalancable_pfmps
     other_pfmps_for_mef
       .select(&:can_be_rebalanced?)
+  end
+
+  def all_pfmps_for_mef
+    student.pfmps
+           .in_state(:completed, :validated)
+           .joins(schooling: :classe)
+           .where("classes.mef_id": mef.id, "classes.school_year_id": school_year.id)
   end
 end

--- a/app/models/concerns/pfmp_amount_calculator.rb
+++ b/app/models/concerns/pfmp_amount_calculator.rb
@@ -19,20 +19,21 @@ module PfmpAmountCalculator
       .sum
   end
 
-  def other_pfmps
+  def other_pfmps_for_mef
     student.pfmps
            .in_state(:completed, :validated)
            .joins(schooling: :classe)
            .where("classes.mef_id": mef.id, "classes.school_year_id": school_year.id)
+           .excluding(self)
   end
 
   def other_priced_pfmps
-    other_pfmps
+    other_pfmps_for_mef
       .where.not(amount: nil)
   end
 
   def rebalancable_pfmps
-    other_pfmps
+    other_pfmps_for_mef
       .select(&:can_be_rebalanced?)
   end
 end

--- a/app/models/pfmp.rb
+++ b/app/models/pfmp.rb
@@ -61,8 +61,6 @@ class Pfmp < ApplicationRecord # rubocop:disable Metrics/ClassLength
   after_create -> { self.administrative_number = administrative_number }
 
   scope :finished, -> { where("pfmps.end_date <= (?)", Time.zone.today) }
-  scope :before, ->(date) { where("pfmps.created_at < (?)", date) }
-  scope :after, ->(date) { where("pfmps.created_at > (?)", date) }
 
   delegate :wage, to: :mef
 

--- a/app/models/pfmp.rb
+++ b/app/models/pfmp.rb
@@ -162,12 +162,9 @@ class Pfmp < ApplicationRecord # rubocop:disable Metrics/ClassLength
     return unless mef
 
     cap = mef.wage.yearly_cap
-    total = student.pfmps
-                   .in_state(:completed, :validated)
-                   .joins(schooling: :classe)
-                   .where("classes.mef_id": mef.id, "classes.school_year_id": school_year.id).sum(:amount)
+    total = all_pfmps_for_mef.sum(:amount)
     return unless total > cap
 
-    errors.add(:amount, "Yearly cap of #{cap} not respected")
+    errors.add(:amount, "Yearly cap of #{cap} not respected for Mef code: #{mef.code}")
   end
 end

--- a/app/models/pfmp_state_machine.rb
+++ b/app/models/pfmp_state_machine.rb
@@ -19,8 +19,7 @@ class PfmpStateMachine
   end
 
   guard_transition(to: :validated) do |pfmp|
-    pfmp.previous_pfmps.not_in_state(:validated).empty? &&
-      pfmp.student.rib(pfmp.classe.establishment).present? &&
+    pfmp.student.rib(pfmp.classe.establishment).present? &&
       pfmp.schooling.attributive_decision.attached?
   end
 

--- a/app/services/pfmp_manager.rb
+++ b/app/services/pfmp_manager.rb
@@ -51,7 +51,7 @@ class PfmpManager
   private
 
   def rebalance_following_pfmps!
-    pfmp.following_rebalancable_pfmps.each do |following_pfmp|
+    pfmp.rebalancable_pfmps.each do |following_pfmp|
       following_pfmp.update!(amount: following_pfmp.calculate_amount)
     end
   end

--- a/app/services/pfmp_manager.rb
+++ b/app/services/pfmp_manager.rb
@@ -8,6 +8,7 @@ class PfmpManager
   class ExistingActivePaymentRequestError < PfmpManagerError; end
   class PfmpNotModifiableError < PfmpManagerError; end
   class PaymentRequestNotIncompleteError < PfmpManagerError; end
+  class YearlyCapExceededError < PfmpManagerError; end
 
   attr_reader :pfmp
 
@@ -20,7 +21,9 @@ class PfmpManager
 
     ApplicationRecord.transaction do
       pfmp.update!(amount: pfmp.calculate_amount)
-      rebalance_following_pfmps!
+      rebalance_other_pfmps!
+
+      check_yearly_cap!
     end
   end
 
@@ -50,9 +53,13 @@ class PfmpManager
 
   private
 
-  def rebalance_following_pfmps!
-    pfmp.rebalancable_pfmps.each do |following_pfmp|
-      following_pfmp.update!(amount: following_pfmp.calculate_amount)
+  def rebalance_other_pfmps!
+    pfmp.rebalancable_pfmps.each do |pfmp|
+      pfmp.update!(amount: pfmp.calculate_amount)
     end
+  end
+
+  def check_yearly_cap!
+    raise YearlyCapExceededError if pfmp.other_pfmps.sum(:amount) > pfmp.mef.wage.yearly_cap
   end
 end

--- a/app/services/pfmp_manager.rb
+++ b/app/services/pfmp_manager.rb
@@ -51,8 +51,8 @@ class PfmpManager
   private
 
   def rebalance_following_pfmps!
-    pfmp.rebalancable_pfmps.each do |following_pfmp|
-      following_pfmp.update!(amount: following_pfmp.calculate_amount)
+    pfmp.rebalancable_pfmps.each do |pfmp|
+      pfmp.update!(amount: pfmp.calculate_amount)
     end
   end
 end

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aplypro
-  VERSION = "1.20.2"
+  VERSION = "1.20.3"
 end

--- a/spec/models/concerns/pfmp_amount_calculator_spec.rb
+++ b/spec/models/concerns/pfmp_amount_calculator_spec.rb
@@ -102,7 +102,7 @@ describe PfmpAmountCalculator do
     end
   end
 
-  describe "#pfmps_for_mef_and_school_year" do
+  describe "#other_pfmps" do
     let(:student) { create(:student, :with_all_asp_info) }
     let(:schooling) { create(:schooling, student: student, classe: classe) }
     let(:pfmp) do
@@ -127,7 +127,7 @@ describe PfmpAmountCalculator do
     end
 
     it "returns the PFMP for the MEF and the current school year" do
-      expect(pfmp.pfmps_for_mef_and_school_year).to contain_exactly(pfmp)
+      expect(pfmp.other_pfmps).to contain_exactly(pfmp)
     end
   end
 end

--- a/spec/models/concerns/pfmp_amount_calculator_spec.rb
+++ b/spec/models/concerns/pfmp_amount_calculator_spec.rb
@@ -108,20 +108,37 @@ describe PfmpAmountCalculator do
              day_count: 3)
     end
 
-    before do
-      old_school_year = create(:school_year, start_year: 2022)
-      old_classe = create(:classe, school_year: old_school_year)
-      old_schooling = create(:schooling, :closed, student: student, classe: old_classe)
-      create(:pfmp,
-             :validated,
-             start_date: "#{old_school_year.start_year}-09-03",
-             end_date: "#{old_school_year.start_year}-09-28",
-             schooling: old_schooling,
-             day_count: 1)
+    context "when there is no other pfmp for that school year and mef" do
+      before do
+        old_school_year = create(:school_year, start_year: 2022)
+        old_classe = create(:classe, school_year: old_school_year)
+        old_schooling = create(:schooling, :closed, student: student, classe: old_classe)
+        create(:pfmp,
+               :validated,
+               start_date: "#{old_school_year.start_year}-09-03",
+               end_date: "#{old_school_year.start_year}-09-28",
+               schooling: old_schooling,
+               day_count: 1)
+      end
+
+      it "returns an empty collection" do
+        expect(pfmp.other_pfmps_for_mef).to be_empty
+      end
     end
 
-    it "returns the other PFMPs for the MEF and the current school year" do
-      expect(pfmp.other_pfmps_for_mef).to be_empty
+    context "when there is another pfmp for the same mef and school year" do
+      before do
+        create(:pfmp,
+               :validated,
+               start_date: "2024-10-03",
+               end_date: "2024-10-28",
+               schooling: schooling,
+               day_count: 3)
+      end
+
+      it "returns the other PFMP for the MEF and the current school year excluding self" do
+        expect(pfmp.other_pfmps_for_mef.pluck(:day_count)).to contain_exactly(3)
+      end
     end
   end
 end

--- a/spec/models/concerns/pfmp_amount_calculator_spec.rb
+++ b/spec/models/concerns/pfmp_amount_calculator_spec.rb
@@ -52,15 +52,13 @@ describe PfmpAmountCalculator do
   it_calculates "the original amount"
 
   context "when the PFMP goes over the yearly cap" do
-    before do
-      pfmp.update!(day_count: 200)
-    end
+    before { pfmp.update!(day_count: 200) }
 
     it_calculates "the yearly-capped amount"
   end
 
-  context "when there is a previous PFMP" do
-    let(:previous) { create(:pfmp, :completed, day_count: 8, created_at: Date.yesterday) }
+  context "when there is another priced PFMP" do
+    let(:previous) { create(:pfmp, :completed, day_count: 8) }
 
     context "with another schooling" do
       let(:schooling) { create(:schooling, :closed, student: pfmp.student) }
@@ -68,9 +66,7 @@ describe PfmpAmountCalculator do
       before { previous.update!(schooling: schooling) }
 
       context "with the same MEF" do
-        before do
-          schooling.classe.update!(mef: mef)
-        end
+        before { schooling.classe.update!(mef: mef) }
 
         it "errors when trying to recalculate" do
           expect { PfmpManager.new(previous.reload).recalculate_amounts! }.to raise_error ActiveRecord::RecordInvalid
@@ -100,7 +96,7 @@ describe PfmpAmountCalculator do
     end
   end
 
-  describe "#other_pfmps" do
+  describe "#other_pfmps_for_mef" do
     let(:student) { create(:student, :with_all_asp_info) }
     let(:schooling) { create(:schooling, student: student, classe: classe) }
     let(:pfmp) do
@@ -124,8 +120,8 @@ describe PfmpAmountCalculator do
              day_count: 1)
     end
 
-    it "returns the PFMP for the MEF and the current school year" do
-      expect(pfmp.other_pfmps).to contain_exactly(pfmp)
+    it "returns the other PFMPs for the MEF and the current school year" do
+      expect(pfmp.other_pfmps_for_mef).to be_empty
     end
   end
 end

--- a/spec/models/pfmp_spec.rb
+++ b/spec/models/pfmp_spec.rb
@@ -91,13 +91,14 @@ RSpec.describe Pfmp do
         end
       end
 
-      context "when the total amount exceeds the yearly cap" do
+      context "when the total amount would exceed the yearly cap" do
         before do
           create(:pfmp, :validated, schooling: schooling, day_count: 10)
         end
 
-        it "is not valid" do
-          expect { pfmp.recalculate_amounts_if_needed }.to raise_error ActiveRecord::RecordInvalid
+        it "caps the amount to 0" do
+          pfmp.save!
+          expect(pfmp.amount).to eq 0
         end
       end
     end
@@ -180,16 +181,6 @@ RSpec.describe Pfmp do
       it "can move to validated" do
         pfmps.last.transition_to!(:validated)
         expect(pfmps.last).to be_in_state(:validated)
-      end
-    end
-
-    context "when previous pfmps are not all validated" do
-      let(:pfmps) { create_list(:pfmp, 3, :can_be_validated, schooling: schooling) }
-
-      before { pfmps.first.transition_to!(:validated) }
-
-      it "cannot move to validated" do
-        expect { pfmps.last.transition_to!(:validated) }.to raise_error Statesman::GuardFailedError
       end
     end
   end

--- a/spec/services/pfmp_manager_spec.rb
+++ b/spec/services/pfmp_manager_spec.rb
@@ -72,7 +72,7 @@ describe PfmpManager do
           expect do
             pfmp.update!(day_count: pfmp.day_count + 8)
           end.to change {
-                   [pfmp.amount] + pfmp.following_rebalancable_pfmps.pluck(:amount)
+                   [pfmp.amount] + pfmp.rebalancable_pfmps.pluck(:amount)
                  }.from([40, 120, 80]).to([200, 120, 80])
         end
       end

--- a/spec/services/pfmp_manager_spec.rb
+++ b/spec/services/pfmp_manager_spec.rb
@@ -72,7 +72,7 @@ describe PfmpManager do
           expect do
             pfmp.update!(day_count: pfmp.day_count + 11)
           end.to change {
-                   [pfmp.amount] + pfmp.following_rebalancable_pfmps.pluck(:amount)
+                   [pfmp.amount] + pfmp.rebalancable_pfmps.pluck(:amount)
                  }.from([40, 120, 80]).to([260, 120, 20])
         end
       end


### PR DESCRIPTION
- Remove the chronological aspect of Pfmps validation: order of validation and reward calculus seems to be irrelevant, seggregating based on time seems to have lead to series of miscalculation
- Rebalance only based on pre-existing Pfmps, simplify logic