### PR TITLE
Add validation for yearly cap

### DIFF
--- a/spec/models/concerns/pfmp_amount_calculator_spec.rb
+++ b/spec/models/concerns/pfmp_amount_calculator_spec.rb
@@ -70,10 +70,11 @@ describe PfmpAmountCalculator do
       context "with the same MEF" do
         before do
           schooling.classe.update!(mef: mef)
-          PfmpManager.new(previous).recalculate_amounts!
         end
 
-        it_calculates "a limited amount", 2
+        it "errors when trying to recalculate" do
+          expect { PfmpManager.new(previous.reload).recalculate_amounts! }.to raise_error ActiveRecord::RecordInvalid
+        end
 
         context "when the classe is from another year" do
           before do
@@ -93,12 +94,9 @@ describe PfmpAmountCalculator do
     end
 
     context "with that schooling" do
-      before do
-        previous.update!(schooling: pfmp.schooling)
-        PfmpManager.new(previous).recalculate_amounts!
+      it "errors" do
+        expect { previous.update!(schooling: pfmp.schooling) }.to raise_error ActiveRecord::RecordInvalid
       end
-
-      it_calculates "a limited amount", 2
     end
   end
 

--- a/spec/models/pfmp_spec.rb
+++ b/spec/models/pfmp_spec.rb
@@ -78,6 +78,29 @@ RSpec.describe Pfmp do
         it { is_expected.to be_valid }
       end
     end
+
+    describe "amounts_yearly_cap" do
+      let(:mef) { create(:mef, daily_rate: 10, yearly_cap: 100) }
+      let(:classe) { create(:classe, mef: mef) }
+      let(:schooling) { create(:schooling, classe: classe) }
+      let(:pfmp) { build(:pfmp, schooling: schooling, day_count: 5) }
+
+      context "when the total amount is within the yearly cap" do
+        it "is valid" do
+          expect(pfmp).to be_valid
+        end
+      end
+
+      context "when the total amount exceeds the yearly cap" do
+        before do
+          create(:pfmp, :validated, schooling: schooling, day_count: 10)
+        end
+
+        it "is not valid" do
+          expect { pfmp.recalculate_amounts_if_needed }.to raise_error ActiveRecord::RecordInvalid
+        end
+      end
+    end
   end
 
   describe "deletion" do

--- a/spec/services/pfmp_manager_spec.rb
+++ b/spec/services/pfmp_manager_spec.rb
@@ -68,12 +68,12 @@ describe PfmpManager do
           create(:pfmp, :completed, schooling: schooling, day_count: 4, created_at: pfmp.created_at + 3.days)
         end
 
-        it "recalculates the follow up modifiable pfmps amounts and caps the last one" do
+        it "recalculates the follow up modifiable pfmps amounts" do
           expect do
-            pfmp.update!(day_count: pfmp.day_count + 11)
+            pfmp.update!(day_count: pfmp.day_count + 8)
           end.to change {
                    [pfmp.amount] + pfmp.following_rebalancable_pfmps.pluck(:amount)
-                 }.from([40, 120, 80]).to([260, 120, 20])
+                 }.from([40, 120, 80]).to([200, 120, 80])
         end
       end
     end


### PR DESCRIPTION
goal:
- make sure no total amount of compensation (Pfmps for one mef) can exceed the yearly cap

before:
- store any amount of days per Pfmp and amount, wait on recalculate method call to check and rebalance

after:
- never store any amount that goes over the yearly cap
