### PR TITLE
Add indexes and amend facade

### DIFF
--- a/app/facades/validations_facade.rb
+++ b/app/facades/validations_facade.rb
@@ -10,16 +10,14 @@ class ValidationsFacade
 
   # TODO: this query somehow (cant reproduce) returns p_r also not in failed state
   # the reject at the end is duct tape to prevent that from happening
-  def failed_pfmps_per_payment_request_state # rubocop:disable Metrics/AbcSize
-    pfmps = Pfmp.joins(schooling: { classe: :establishment })
-                .where(establishments: { id: establishment.id })
-                .joins(:payment_requests)
-                .joins("INNER JOIN (#{establishment.latest_per_pfmp.failed.to_sql}) as latest_payment_requests
+  def failed_pfmps_per_payment_request_state
+    subquery = establishment.payment_requests.latest_per_pfmp.failed.to_sql
+    pfmps = Pfmp.joins("INNER JOIN (#{subquery}) as latest_payment_requests
                         ON latest_payment_requests.pfmp_id = pfmps.id")
                 .includes(:student, payment_requests: :asp_payment_request_transitions)
 
     pfmps.group_by { |pfmp| pfmp.latest_payment_request.current_state }
-         .reject { |pfmp_state| ASP::PaymentRequestStateMachine::FAILED_STATES.exclude?(pfmp_state.to_sym) }
+         .reject { |pr_state| ASP::PaymentRequestStateMachine::FAILED_STATES.exclude?(pr_state.to_sym) }
   end
 
   def validatable_classes

--- a/app/facades/validations_facade.rb
+++ b/app/facades/validations_facade.rb
@@ -10,13 +10,11 @@ class ValidationsFacade
 
   # TODO: this query somehow (cant reproduce) returns p_r also not in failed state
   # the reject at the end is duct tape to prevent that from happening
-  def failed_pfmps_per_payment_request_state
-    subquery = ASP::PaymentRequest.latest_per_pfmp.failed.to_sql
-
+  def failed_pfmps_per_payment_request_state # rubocop:disable Metrics/AbcSize
     pfmps = Pfmp.joins(schooling: { classe: :establishment })
                 .where(establishments: { id: establishment.id })
                 .joins(:payment_requests)
-                .joins("INNER JOIN (#{subquery}) as latest_payment_requests
+                .joins("INNER JOIN (#{establishment.latest_per_pfmp.failed.to_sql}) as latest_payment_requests
                         ON latest_payment_requests.pfmp_id = pfmps.id")
                 .includes(:student, payment_requests: :asp_payment_request_transitions)
 

--- a/app/models/schooling.rb
+++ b/app/models/schooling.rb
@@ -16,10 +16,10 @@ class Schooling < ApplicationRecord # rubocop:disable Metrics/ClassLength
   has_one :establishment, through: :classe
 
   scope :former, -> { where.not(end_date: nil).where(end_date: ..Date.current) }
-  scope :current, -> { where.not(id: former).where(id: without_removed_students) }
-
-  scope :with_removed_students, -> { where.not(removed_at: nil) }
+  scope :active, -> { where("schoolings.end_date IS NULL OR schoolings.end_date > ?", Date.current) }
+  scope :current, -> { active.without_removed_students }
   scope :without_removed_students, -> { where(removed_at: nil) }
+  scope :with_removed_students, -> { where.not(removed_at: nil) }
 
   scope :with_attributive_decisions, -> { joins(:attributive_decision_attachment) }
   scope :without_attributive_decisions, -> { where.missing(:attributive_decision_attachment) }

--- a/db/migrate/20241104214101_add_indexes_for_establishment_facade.rb
+++ b/db/migrate/20241104214101_add_indexes_for_establishment_facade.rb
@@ -1,0 +1,7 @@
+class AddIndexesForEstablishmentFacade < ActiveRecord::Migration[7.2]
+  def change
+    add_index :asp_payment_requests, [:pfmp_id, :created_at]
+    add_index :classes, [:establishment_id, :school_year_id]
+    add_index :schoolings, [:student_id, :end_date, :removed_at]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_14_094756) do
+ActiveRecord::Schema[7.2].define(version: 2024_11_04_214101) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -50,6 +50,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_14_094756) do
     t.boolean "most_recent", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["asp_payment_request_id", "most_recent"], name: "idx_on_asp_payment_request_id_most_recent_77301c2812"
     t.index ["asp_payment_request_id", "most_recent"], name: "index_asp_payment_request_transitions_parent_most_recent", unique: true, where: "most_recent"
     t.index ["asp_payment_request_id", "sort_key"], name: "index_asp_payment_request_transitions_parent_sort", unique: true
   end
@@ -63,6 +64,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_14_094756) do
     t.bigint "rib_id"
     t.index ["asp_payment_return_id"], name: "index_asp_payment_requests_on_asp_payment_return_id"
     t.index ["asp_request_id"], name: "index_asp_payment_requests_on_asp_request_id"
+    t.index ["pfmp_id", "created_at"], name: "index_asp_payment_requests_on_pfmp_id_and_created_at"
     t.index ["pfmp_id"], name: "index_asp_payment_requests_on_pfmp_id"
     t.index ["rib_id"], name: "index_asp_payment_requests_on_rib_id"
   end
@@ -97,6 +99,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_14_094756) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "school_year_id", null: false
+    t.index ["establishment_id", "school_year_id"], name: "index_classes_on_establishment_id_and_school_year_id"
     t.index ["establishment_id"], name: "index_classes_on_establishment_id"
     t.index ["mef_id"], name: "index_classes_on_mef_id"
     t.index ["school_year_id"], name: "index_classes_on_school_year_id"
@@ -239,6 +242,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_14_094756) do
     t.index ["asp_dossier_id"], name: "index_schoolings_on_asp_dossier_id", unique: true
     t.index ["classe_id"], name: "index_schoolings_on_classe_id"
     t.index ["student_id", "classe_id"], name: "one_schooling_per_class_student", unique: true
+    t.index ["student_id", "end_date", "removed_at"], name: "index_schoolings_on_student_id_and_end_date_and_removed_at"
     t.index ["student_id"], name: "index_schoolings_on_student_id"
     t.index ["student_id"], name: "one_active_schooling_per_student", unique: true, where: "(end_date IS NULL)"
   end


### PR DESCRIPTION
Fix performance of this monster for sure by not using IN:

```rb
"schoolings"."student_id" = $1 AND "schoolings"."id" NOT IN (SELECT "schoolings"."id" FROM "schoolings" WHERE "schoolings"."end_date" IS NOT NULL AND "schoolings"."end_date" <= $2) AND "schoolings"."id" IN (SELECT "schoolings"."id" FROM "schoolings" WHERE "schoolings"."removed_at" IS NULL) LIMIT $3
```

and potentially fix/improve this one too:

```rb
SELECT COUNT(*) AS "count_all", "to_state" AS "to_state" FROM (SELECT DISTINCT ON (pfmp_id) * FROM "asp_payment_requests" ORDER BY pfmp_id, created_at DESC) as asp_payment_requests INNER JOIN "pfmps" ON "asp_payment_requests"."pfmp_id" = "pfmps"."id" INNER JOIN "schoolings" ON "pfmps"."schooling_id" = "schoolings"."id" INNER JOIN "classes" ON "schoolings"."classe_id" = "classes"."id" INNER JOIN "school_years" "school_year" ON "school_year"."id" = "classes"."school_year_id" LEFT OUTER JOIN asp_payment_request_transitions AS most_recent_asp_payment_request_transition ON asp_payment_requests.id = most_recent_asp_payment_request_transition.asp_payment_request_id AND most_recent_asp_payment_request_transition.most_recent = $3 WHERE "classes"."establishment_id" = $1 AND "school_year"."start_year" = $2 GROUP BY "to_state"
```