### PR TITLE
Prends uniquement en compte les élèves actifs pour les actions en masse d'une classe

### DIFF
--- a/app/controllers/ribs_controller.rb
+++ b/app/controllers/ribs_controller.rb
@@ -51,7 +51,7 @@ class RibsController < ApplicationController # rubocop:disable Metrics/ClassLeng
 
   def missing
     @ribs = @classe
-            .students
+            .active_students
             .without_ribs
             .map { |student| Rib.new(student: student, owner_type: :personal, name: student.full_name) }
   end

--- a/app/facades/classe_facade.rb
+++ b/app/facades/classe_facade.rb
@@ -6,11 +6,11 @@ class ClasseFacade
   end
 
   def nb_pending_pfmps
-    @nb_pending_pfmps ||= @classe.active_pfmps.in_state(:pending).count
+    @nb_pending_pfmps ||= @classe.pfmps.in_state(:pending).count
   end
 
   def nb_can_transition_to_validated_pfmps
-    @nb_can_transition_to_validated_pfmps ||= @classe.active_pfmps
+    @nb_can_transition_to_validated_pfmps ||= @classe.pfmps
                                                      .in_state(:completed)
                                                      .filter { |pfmp| pfmp.can_transition_to?(:validated) }
                                                      .count

--- a/app/facades/classe_facade.rb
+++ b/app/facades/classe_facade.rb
@@ -20,8 +20,8 @@ class ClasseFacade
     @nb_missing_ribs ||= @classe.active_students.without_ribs.count
   end
 
-  def nb_active_schoolings
-    @nb_active_schoolings ||= @classe.active_students.count
+  def any_active_schoolings?
+    @any_active_schoolings ||= @classe.active_students.any?
   end
 
   def schoolings

--- a/app/facades/classe_facade.rb
+++ b/app/facades/classe_facade.rb
@@ -6,17 +6,22 @@ class ClasseFacade
   end
 
   def nb_pending_pfmps
-    @nb_pending_pfmps ||= @classe.pfmps.in_state(:pending).count
+    @nb_pending_pfmps ||= @classe.active_pfmps.in_state(:pending).count
   end
 
   def nb_can_transition_to_validated_pfmps
-    @nb_can_transition_to_validated_pfmps ||= @classe.pfmps.in_state(:completed)
+    @nb_can_transition_to_validated_pfmps ||= @classe.active_pfmps
+                                                     .in_state(:completed)
                                                      .filter { |pfmp| pfmp.can_transition_to?(:validated) }
                                                      .count
   end
 
   def nb_missing_ribs
-    @nb_missing_ribs ||= @classe.students.without_ribs.count
+    @nb_missing_ribs ||= @classe.active_students.without_ribs.count
+  end
+
+  def nb_active_schoolings
+    @nb_active_schoolings ||= @classe.active_students.count
   end
 
   def schoolings

--- a/app/views/classes/show.html.haml
+++ b/app/views/classes/show.html.haml
@@ -3,8 +3,9 @@
 .actions.fr-btns-group.fr-btns-group--inline
   - if @classe_facade.nb_missing_ribs > 0
     = link_to @classe_facade.missing_ribs_button_text, missing_school_year_class_ribs_path(selected_school_year, @classe), class: 'fr-btn fr-btn--primary'
-  
-  = link_to 'Saisir une PFMP pour toute la classe', bulk_pfmp_school_year_class_path(selected_school_year, @classe), class: 'fr-btn fr-btn--primary'
+
+  - if @classe_facade.nb_active_schoolings > 0
+    = link_to 'Saisir une PFMP pour toute la classe', bulk_pfmp_school_year_class_path(selected_school_year, @classe), class: 'fr-btn fr-btn--primary'
 
 .actions.fr-btns-group.fr-btns-group--inline
   - if @classe_facade.nb_pending_pfmps > 0

--- a/app/views/classes/show.html.haml
+++ b/app/views/classes/show.html.haml
@@ -4,7 +4,7 @@
   - if @classe_facade.nb_missing_ribs > 0
     = link_to @classe_facade.missing_ribs_button_text, missing_school_year_class_ribs_path(selected_school_year, @classe), class: 'fr-btn fr-btn--primary'
 
-  - if @classe_facade.nb_active_schoolings > 0
+  - if @classe_facade.any_active_schoolings?
     = link_to 'Saisir une PFMP pour toute la classe', bulk_pfmp_school_year_class_path(selected_school_year, @classe), class: 'fr-btn fr-btn--primary'
 
 .actions.fr-btns-group.fr-btns-group--inline

--- a/features/1_gestion_des_scolarités.feature
+++ b/features/1_gestion_des_scolarités.feature
@@ -14,8 +14,9 @@ Fonctionnalité: Gestion des scolarités de l'élève
     Et que je clique sur "Confirmer le retrait de l'élève de la classe"
     Alors la page contient "L'élève Jean Dupuis a bien été retiré de la classe 1MELEC"
     Et je peux voir dans le tableau "Élèves retirés manuellement de la classe"
-      | Élèves (1)    | Réintégration de l'élève dans la classe |
+      | Élèves (1)    | Réintégration de l'élève dans la classe      |
       | Dupuis Jean   | Réintégrer Jean Dupuis dans la classe 1MELEC |
+    Et la page contient "Saisir 9 coordonnées bancaires"
     Quand je consulte le profil de "Jean Dupuis" dans la classe de "1MELEC"
     Alors la page contient "Retiré(e) manuellement de la classe"
     Quand je consulte la classe "1MELEC"

--- a/features/anciens_eleves.feature
+++ b/features/anciens_eleves.feature
@@ -64,6 +64,7 @@ Fonctionnalité: Les anciens élèves sont inclus à part dans l'interface
     Alors je peux voir dans le tableau "Élèves sortis de la classe"
       | Élèves (1)  | Décisions d'attribution | Coordonnées Bancaires (1/1) | PFMPs (0) |
       | Dupuis Jean |                         | Saisies                     |           |
+    Et la page contient "Saisir 9 coordonnées bancaires"
 
   Scénario: Le personnel peut créer une PFMP pour un ancien élève
     Quand je consulte la classe de "1MELEC"


### PR DESCRIPTION
Seules les actions `Saisir X coordonnée(s) bancaire(s)` et `Saisir une PFMP pour toute la classe` ont été modifiées