### PR TITLE
Fix broken student info call for Fregata students

### DIFF
--- a/app/apis/students_api/fregata/api.rb
+++ b/app/apis/students_api/fregata/api.rb
@@ -35,8 +35,8 @@ module StudentsApi
         end
 
         def student_endpoint(params)
-          uai = Student
-                .find_by!(ine: params[:ine])
+          uai = params[:uai] || Student
+                .find_by!(ine: params.fetch(:ine))
                 .current_schooling
                 .establishment
                 .uai

--- a/app/jobs/sync/student_job.rb
+++ b/app/jobs/sync/student_job.rb
@@ -20,7 +20,7 @@ module Sync
 
     def fetch_student_data(schooling)
       api = schooling.establishment.students_api
-      api.fetch_resource(:student, ine: schooling.student.ine)
+      api.fetch_resource(:student, ine: schooling.student.ine, uai: schooling.establishment.uai)
          .then { |data| map_student_attributes(data, api) }
          .then { |attributes| schooling.student.update!(attributes) }
 

--- a/spec/apis/students_api/fregata/api_spec.rb
+++ b/spec/apis/students_api/fregata/api_spec.rb
@@ -11,11 +11,37 @@ describe StudentsApi::Fregata::Api do
     mock_fregata_students_with(uai, "")
   end
 
+  describe "student_endpoint" do
+    let(:student) { create(:schooling).student }
+    let(:uai) { student.current_schooling.establishment.uai }
+
+    context "when uai is provided directly" do
+      it "returns the establishment_students_endpoint with that uai" do
+        endpoint = api.student_endpoint(uai: uai)
+        expect(endpoint).to eq api.establishment_students_endpoint(uai: uai)
+      end
+    end
+
+    context "when only ine is provided" do
+      it "finds the student's establishment uai and returns the corresponding endpoint" do
+        endpoint = api.student_endpoint(ine: student.ine)
+        expect(endpoint).to eq api.establishment_students_endpoint(uai: uai)
+      end
+    end
+
+    context "when student ine is not found" do
+      it "raises ActiveRecord::RecordNotFound" do
+        expect { api.student_endpoint(ine: "invalid_ine") }
+          .to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
   describe "fetch_establishment_students!" do
     it "queries the right endpoint with the right parameters" do
       api.fetch_resource(:establishment_students, uai: uai)
 
-      # this will break whenever we add a year in the school_year_seeder
+      # TODO: this will break whenever we add a year in the school_year_seeder
       expect(WebMock)
         .to have_requested(:get, api.establishment_students_endpoint(uai: uai))
         .with(query: { rne: uai, anneeScolaireId: 28 })


### PR DESCRIPTION
Pass optional param :uai to still be able to find Students that may have a closed Schooling on our side

OR Should we consider that if their schooling is closed we should not fetch their info? This might be difficult because Fregata uses Establishment listing to give student info and if the schooling is closed the student probably doesnt show up anymore but we still need his/her most up to date data for payments, etc.

🤔 