### PR TITLE
Sync Student info upon rectification

### DIFF
--- a/app/models/pfmp_state_machine.rb
+++ b/app/models/pfmp_state_machine.rb
@@ -31,6 +31,7 @@ class PfmpStateMachine
   after_transition(to: :rectified) do |pfmp|
     new_payment_request = PfmpManager.new(pfmp).create_new_payment_request!
     new_payment_request.mark_ready!
+    Sync::StudentJob.perform_later(pfmp.schooling)
   end
 
   after_transition(to: :validated) do |pfmp|


### PR DESCRIPTION
Because we need the address.