### PR TITLE
Reduce margin for cancellation decision document to fit on one page + Rework student pfmp page

### DIFF
--- a/app/views/pfmps/_pfmp_student_table.html.haml
+++ b/app/views/pfmps/_pfmp_student_table.html.haml
@@ -31,5 +31,5 @@
                 %td
                   %strong= number_to_currency(pfmp.amount)
 
-      - if classe.establishment.eql?(current_establishment)
-        = render "pfmps/schooling_buttons", schooling: schooling, school_year: school_year, classe: classe, student: @student
+    - if classe.establishment.eql?(current_establishment)
+      = render "pfmps/schooling_buttons", schooling: schooling, school_year: school_year, classe: classe, student: @student

--- a/app/views/pfmps/_pfmp_student_table.html.haml
+++ b/app/views/pfmps/_pfmp_student_table.html.haml
@@ -1,4 +1,5 @@
 - schoolings.sort_by{ |schooling| schooling.classe.school_year.start_year}.reverse.each do |schooling|
+  %h2 Scolarités
   - pfmps = schooling.pfmps
   - classe = schooling.classe
   - school_year = classe.school_year
@@ -30,19 +31,5 @@
                 %td
                   %strong= number_to_currency(pfmp.amount)
 
-    - if classe.establishment.eql?(current_establishment)
-      .actions
-        .fr-btns-group.fr-btns-group--inline
-          = button_to "Ajouter une PFMP", new_school_year_class_schooling_pfmp_path(school_year, classe, schooling), class: 'fr-btn', method: :get
-          - if schooling.attributive_decision.attached?
-            = button_to "Télécharger la décision d'attribution", url_for(schooling.attributive_decision), class: 'fr-btn fr-btn--secondary', target: :download, method: :get
-            - if !schooling.cancellation_decision.attached? && !Rails.env.production?
-              = button_to "Retirer la décision d'attribution", confirm_cancellation_decision_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
-              = render partial: "shared/tooltip", locals: { message: "cancellation_decision", id: 1 }
-          - if schooling.abrogation_decision.attached?
-            = button_to "Télécharger la décision d'abrogation", url_for(schooling.abrogation_decision), class: 'fr-btn fr-btn--secondary', target: :download, method: :get
-          - if schooling.cancellation_decision.attached? && !Rails.env.production?
-            = button_to "Télécharger la décision de retrait", url_for(schooling.cancellation_decision), class: 'fr-btn fr-btn--secondary', target: :download, method: :get
-          - if !@student.current_schooling.nil? && @student.current_schooling.eql?(schooling) && !schooling.removed?
-            = button_to "Masquer l'élève de la classe",  confirm_removal_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
-            = render partial: "shared/tooltip", locals: { message: "remove_student", id: 1 }
+      - if classe.establishment.eql?(current_establishment)
+        = render "pfmps/schooling_buttons", schooling: schooling, school_year: school_year, classe: classe, student: @student

--- a/app/views/pfmps/_schooling_buttons.html.haml
+++ b/app/views/pfmps/_schooling_buttons.html.haml
@@ -10,7 +10,7 @@
             %li
               = button_to "Masquer l'élève de la classe", confirm_removal_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
               = render partial: "shared/tooltip", locals: { message: "remove_student", id: 1 }
-          - if schooling.attributive_decision.attached? && !schooling.cancellation_decision.attached? && !Rails.env.production?
+          - if schooling.attributive_decision.attached? && !schooling.cancellation_decision.attached?
             %li
               = button_to "Retirer la décision d'attribution", confirm_cancellation_decision_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
               = render partial: "shared/tooltip", locals: { message: "cancellation_decision", id: 2 }
@@ -27,7 +27,7 @@
           %li
             = link_to url_for(schooling.abrogation_decision), class: 'fr-link fr-link--download', download: true do
               Télécharger la décision d'abrogation
-        - if schooling.cancellation_decision.attached? && !Rails.env.production?
+        - if schooling.cancellation_decision.attached?
           %li
             = link_to url_for(schooling.cancellation_decision), class: 'fr-link fr-link--download', download: true do
               Télécharger la décision de retrait

--- a/app/views/pfmps/_schooling_buttons.html.haml
+++ b/app/views/pfmps/_schooling_buttons.html.haml
@@ -15,7 +15,7 @@
                   = button_to "Masquer l'élève de la classe", confirm_removal_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
                 .fr-col-2
                   = render partial: "shared/tooltip", locals: { message: "remove_student", id: 1 }
-          - if schooling.attributive_decision.attached? && !schooling.cancellation_decision.attached?
+          - if !Rails.env.production? && schooling.attributive_decision.attached? && !schooling.cancellation_decision.attached?
             %li
               .fr-grid-row.fr-grid-row--middle
                 .fr-col-10

--- a/app/views/pfmps/_schooling_buttons.html.haml
+++ b/app/views/pfmps/_schooling_buttons.html.haml
@@ -1,0 +1,33 @@
+.fr-grid-row.fr-grid-row--gutters
+  .fr-col-md-6
+    %h3.fr-h6 Actions
+    .fr-grid-row
+      .fr-col-10
+        %ul.fr-btns-group.fr-btns-group--sm
+          %li
+            = button_to "Ajouter une PFMP", new_school_year_class_schooling_pfmp_path(school_year, classe, schooling), class: 'fr-btn', method: :get
+          - if !student.current_schooling.nil? && student.current_schooling.eql?(schooling) && !schooling.removed?
+            %li
+              = button_to "Masquer l'élève de la classe", confirm_removal_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
+              = render partial: "shared/tooltip", locals: { message: "remove_student", id: 1 }
+          - if schooling.attributive_decision.attached? && !schooling.cancellation_decision.attached? && !Rails.env.production?
+            %li
+              = button_to "Retirer la décision d'attribution", confirm_cancellation_decision_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
+              = render partial: "shared/tooltip", locals: { message: "cancellation_decision", id: 2 }
+
+  - if schooling.attributive_decision.attached? || schooling.abrogation_decision.attached? || schooling.cancellation_decision.attached?
+    .fr-col-md-6
+      %h3.fr-h6 Documents administratifs
+      %ul.fr-links-group
+        - if schooling.attributive_decision.attached?
+          %li
+            = link_to url_for(schooling.attributive_decision), class: 'fr-link fr-link--download', download: true do
+              Télécharger la décision d'attribution
+        - if schooling.abrogation_decision.attached?
+          %li
+            = link_to url_for(schooling.abrogation_decision), class: 'fr-link fr-link--download', download: true do
+              Télécharger la décision d'abrogation
+        - if schooling.cancellation_decision.attached? && !Rails.env.production?
+          %li
+            = link_to url_for(schooling.cancellation_decision), class: 'fr-link fr-link--download', download: true do
+              Télécharger la décision de retrait

--- a/app/views/pfmps/_schooling_buttons.html.haml
+++ b/app/views/pfmps/_schooling_buttons.html.haml
@@ -5,15 +5,23 @@
       .fr-col-10
         %ul.fr-btns-group.fr-btns-group--sm
           %li
-            = button_to "Ajouter une PFMP", new_school_year_class_schooling_pfmp_path(school_year, classe, schooling), class: 'fr-btn', method: :get
+            .fr-grid-row
+              .fr-col-10
+                = button_to "Ajouter une PFMP", new_school_year_class_schooling_pfmp_path(school_year, classe, schooling), class: 'fr-btn', method: :get
           - if !student.current_schooling.nil? && student.current_schooling.eql?(schooling) && !schooling.removed?
             %li
-              = button_to "Masquer l'élève de la classe", confirm_removal_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
-              = render partial: "shared/tooltip", locals: { message: "remove_student", id: 1 }
+              .fr-grid-row.fr-grid-row--middle
+                .fr-col-10
+                  = button_to "Masquer l'élève de la classe", confirm_removal_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
+                .fr-col-2
+                  = render partial: "shared/tooltip", locals: { message: "remove_student", id: 1 }
           - if schooling.attributive_decision.attached? && !schooling.cancellation_decision.attached?
             %li
-              = button_to "Retirer la décision d'attribution", confirm_cancellation_decision_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
-              = render partial: "shared/tooltip", locals: { message: "cancellation_decision", id: 2 }
+              .fr-grid-row.fr-grid-row--middle
+                .fr-col-10
+                  = button_to "Retirer la décision d'attribution", confirm_cancellation_decision_school_year_class_schooling_path(school_year, classe, schooling), class: 'fr-btn fr-btn--danger', method: :get
+                .fr-col-2
+                  = render partial: "shared/tooltip", locals: { message: "cancellation_decision", id: 2 }
 
   - if schooling.attributive_decision.attached? || schooling.abrogation_decision.attached? || schooling.cancellation_decision.attached?
     .fr-col-md-6

--- a/lib/attribute_decision/cancellation.rb
+++ b/lib/attribute_decision/cancellation.rb
@@ -4,7 +4,12 @@
 module AttributeDecision
   # Generate "Décision de retrait"
   class Cancellation < DocumentGenerator
+
     private
+
+    def margin
+      34
+    end
 
     def articles
       composer.text("Décide :", style: :paragraph_title)

--- a/lib/attribute_decision/document_generator.rb
+++ b/lib/attribute_decision/document_generator.rb
@@ -9,7 +9,7 @@ module AttributeDecision
     attr_reader :composer, :schooling, :student, :school_year
 
     def initialize(schooling)
-      @composer = HexaPDF::Composer.new(page_size: :A4, margin: 48)
+      @composer = HexaPDF::Composer.new(page_size: :A4, margin: margin)
       @schooling = schooling
       @student = schooling.student
       @school_year = schooling.classe.school_year
@@ -24,6 +24,10 @@ module AttributeDecision
     end
 
     private
+
+    def margin
+      48
+    end
 
     def render
       setup_styles


### PR DESCRIPTION
- Reduce margin for cancellation decision document to fit on one page
- Release cancellation feature
- Rework action + document links on student pfmp table page show
- Use download styling for dl links from dsfr