### PR TITLE
Mitigate address length issues

### DIFF
--- a/app/apis/students_api/fregata/mappers/address_mapper.rb
+++ b/app/apis/students_api/fregata/mappers/address_mapper.rb
@@ -20,15 +20,18 @@ module StudentsApi
             communeCodeInsee: :address_city_insee_code
           )
 
-          nest :address_line1, %i[ligne2 ligne3 ligne4 ligne5 ligne6 ligne7]
+          nest :address_line1, %i[ligne2 ligne3 ligne4]
+          nest :address_line2, %i[ligne5 ligne6 ligne7]
 
           map_value :address_line1, ->(hash) { hash.values.compact.join(" ") }
+          map_value :address_line2, ->(hash) { hash.values.compact.join(" ") }
 
           accept_keys %i[
             address_postal_code
             address_country_code
             address_city_insee_code
             address_line1
+            address_line2
           ]
 
           catch_empty_address

--- a/app/apis/students_api/sygne/mappers/address_mapper.rb
+++ b/app/apis/students_api/sygne/mappers/address_mapper.rb
@@ -21,9 +21,11 @@ module StudentsApi
             inseePaysNaissance: :birthplace_country_insee_code
           )
 
-          nest :address_line1, %i[adresseLigne1 adresseLigne2 adresseLigne3 adresseLigne4]
+          nest :address_line1, %i[adresseLigne1 adresseLigne2]
+          nest :address_line2, %i[adresseLigne3 adresseLigne4]
 
           map_value :address_line1, ->(hash) { hash.values.compact.join(" ") }
+          map_value :address_line2, ->(hash) { hash.values.compact.join(" ") }
 
           accept_keys %i[
             address_postal_code
@@ -31,6 +33,7 @@ module StudentsApi
             address_city
             address_city_insee_code
             address_line1
+            address_line2
             biological_sex
             birthplace_city_insee_code
             birthplace_country_insee_code

--- a/spec/apis/students_api/sygne/mappers/address_mapper_spec.rb
+++ b/spec/apis/students_api/sygne/mappers/address_mapper_spec.rb
@@ -9,8 +9,8 @@ describe StudentsApi::Sygne::Mappers::AddressMapper do
 
   let(:expected) do
     {
-      address_line1: [data["adrResidenceEle"]["adresseLigne1"], data["adrResidenceEle"]["adresseLigne2"],
-                      data["adrResidenceEle"]["adresseLigne3"], data["adrResidenceEle"]["adresseLigne4"]].join(" "),
+      address_line1: [data["adrResidenceEle"]["adresseLigne1"], data["adrResidenceEle"]["adresseLigne2"]].join(" "),
+      address_line2: [data["adrResidenceEle"]["adresseLigne3"], data["adrResidenceEle"]["adresseLigne4"]].join(" "),
       address_postal_code: data["adrResidenceEle"]["codePostal"],
       address_city: data["adrResidenceEle"]["libelleCommune"],
       address_city_insee_code: data["adrResidenceEle"]["codeCommuneInsee"],
@@ -27,9 +27,9 @@ describe StudentsApi::Sygne::Mappers::AddressMapper do
   context "when address_line2 is nil" do
     before { data["adrResidenceEle"]["adresseLigne2"] = nil }
 
-    it "maps addresses correctly" do
-      expect(mapper.call(data)[:address_line1]).to eq [data["adrResidenceEle"]["adresseLigne1"],
-                                                       data["adrResidenceEle"]["adresseLigne3"],
+    it "maps addresses correctly" do # rubocop:disable RSpec/MultipleExpectations
+      expect(mapper.call(data)[:address_line1]).to eq data["adrResidenceEle"]["adresseLigne1"]
+      expect(mapper.call(data)[:address_line2]).to eq [data["adrResidenceEle"]["adresseLigne3"],
                                                        data["adrResidenceEle"]["adresseLigne4"]].join(" ")
     end
   end


### PR DESCRIPTION
- Lets split all the elements we get from the api on the 2 lines available instead of sticking it on one line