### PR TITLE
use PFMP acronyme everywhere on stats page

### DIFF
--- a/app/views/stats/_map.html.haml
+++ b/app/views/stats/_map.html.haml
@@ -1,5 +1,7 @@
 .stat
-  %h3 Répartition géographique des montants des PFMPs
+  %h3
+    Répartition géographique des montants des 
+    %acronym{title: "Période de formation en milieu professionnel"} PFMPs
   .map-section
     %h4.text-center Métropole
     #map-container{

--- a/app/views/stats/index.html.haml
+++ b/app/views/stats/index.html.haml
@@ -1,6 +1,8 @@
 .fr-grid-row.fr-grid-row--gutters
   .fr-col-12
-    %h2 Statistiques de paiement des PFMPs
+    %h2 
+      Statistiques de paiement des
+      %acronym{title: "Période de formation en milieu professionnel"} PFMPs
   .fr-col-12.fr-col-md-6
     .fr-grid-row.fr-grid-row--gutters
       .fr-col-12
@@ -23,7 +25,10 @@
 
       .fr-col-12
         .stat
-          %h3 Nombre de PFMPs payées par mois
+          %h3
+            Nombre de 
+            %acronym{title: "Période de formation en milieu professionnel"} PFMPs
+            payées par mois
           = column_chart paid_pfmps_per_month_stats_path, label: "nombre de stages payés"
 
   .fr-col-12.fr-col-md-6


### PR DESCRIPTION
Je passais sur la page de stats d'APLyPro, et j'ai eu envie de modifier ça.
C'est un détail, mais ça me frustre les acronymes alors je fait la PR direct :p

(J'ai pas testé en local, j'ai fait ça dans l'éditeur de github).