### PR TITLE
Fix correction addresse job

### DIFF
--- a/app/jobs/send_correction_adresse_job.rb
+++ b/app/jobs/send_correction_adresse_job.rb
@@ -4,6 +4,8 @@ class SendCorrectionAdresseJob < ApplicationJob
   queue_as :payments
   sidekiq_options retry: false
 
+  RNVP_STUDENT_BATCH_THRESHOLD = 10
+
   def perform(pfmp_ids)
     payment_requests = Pfmp.where(id: pfmp_ids)
                            .filter_map { |pfmp| pfmp.payment_requests.order(:created_at).last }
@@ -18,7 +20,18 @@ class SendCorrectionAdresseJob < ApplicationJob
   private
 
   def enrich_with_rnvp!(students)
-    data = Omogen::Rnvp.new.addresses(students).index_by { |address| address[:id] }
-    students.each { |s| s.rnvp_data = data[s.id] }
+    rnvp = Omogen::Rnvp.new
+    data = fetch_rnvp_data(rnvp, students)
+    students.each do |s|
+      s.rnvp_data = data[s.id] || raise(ASP::Errors::MissingRnvpDataError, "No RNVP data for student #{s.id}")
+    end
+  end
+
+  def fetch_rnvp_data(rnvp, students)
+    if students.count > RNVP_STUDENT_BATCH_THRESHOLD
+      rnvp.addresses(students).index_by { |address| address[:id] }
+    else
+      students.to_h { |s| [s.id, rnvp.address(s)] }
+    end
   end
 end

--- a/app/models/asp/errors.rb
+++ b/app/models/asp/errors.rb
@@ -14,6 +14,7 @@ module ASP
     class NegativeRectificationError < Error; end
     class MissingEstablishmentCommuneCodeError < Error; end
     class MissingEstablishmentPostalCodeError < Error; end
+    class MissingRnvpDataError < Error; end
     class PaymentFileValidationError < Error; end
     class ReadingFileError < Error; end
 

--- a/spec/jobs/send_correction_adresse_job_spec.rb
+++ b/spec/jobs/send_correction_adresse_job_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe SendCorrectionAdresseJob do
   before do
     allow(ASP::Request).to receive(:create!).and_return(request_double)
     allow(Omogen::Rnvp).to receive(:new).and_return(rnvp_double)
-    allow(rnvp_double).to receive(:addresses).and_return([{}])
+    allow(rnvp_double).to receive(:address) { |student| { id: student.id } }
+    allow(rnvp_double).to receive(:addresses) { |students| students.map { |s| { id: s.id } } }
   end
 
   it "creates a correction adresse ASP request" do
@@ -21,12 +22,6 @@ RSpec.describe SendCorrectionAdresseJob do
 
     expect(ASP::Request).to have_received(:create!).with(correction_adresse: true)
     expect(request_double).to have_received(:send_correction_adresse!)
-  end
-
-  it "calls RNVP one time for all students" do
-    described_class.perform_now(pfmp_ids)
-
-    expect(rnvp_double).to have_received(:addresses).exactly(1).time
   end
 
   context "when no PFMPs are found" do
@@ -43,6 +38,42 @@ RSpec.describe SendCorrectionAdresseJob do
     end
   end
 
+  context "when the number of students is below the batch threshold" do
+    it "calls address once per student" do
+      described_class.perform_now(pfmp_ids)
+
+      expect(rnvp_double).to have_received(:address).exactly(pfmps.count).times
+      expect(rnvp_double).not_to have_received(:addresses)
+    end
+
+    context "when a student has no RNVP data" do
+      before { allow(rnvp_double).to receive(:address).and_return(nil) }
+
+      it "raises MissingRnvpDataError" do
+        expect { described_class.perform_now(pfmp_ids) }.to raise_error(ASP::Errors::MissingRnvpDataError)
+      end
+    end
+  end
+
+  context "when the number of students exceeds the batch threshold" do
+    let(:pfmps) { create_list(:pfmp, described_class::RNVP_STUDENT_BATCH_THRESHOLD + 1, :rectified) }
+
+    it "calls addresses once for all students" do
+      described_class.perform_now(pfmp_ids)
+
+      expect(rnvp_double).to have_received(:addresses).exactly(1).time
+      expect(rnvp_double).not_to have_received(:address)
+    end
+
+    context "when a student has no RNVP data" do
+      before { allow(rnvp_double).to receive(:addresses).and_return([]) }
+
+      it "raises MissingRnvpDataError" do
+        expect { described_class.perform_now(pfmp_ids) }.to raise_error(ASP::Errors::MissingRnvpDataError)
+      end
+    end
+  end
+
   context "when a student has two PFMPs in the list" do # rubocop:disable RSpec/MultipleMemoizedHelpers
     let(:schooling) { create(:schooling) }
     let(:student) { schooling.student }
@@ -51,7 +82,7 @@ RSpec.describe SendCorrectionAdresseJob do
     it "sends the student only once" do
       described_class.perform_now(pfmp_ids)
 
-      expect(rnvp_double).to have_received(:addresses).with([student])
+      expect(rnvp_double).to have_received(:address).with(student).once
     end
   end
 end


### PR DESCRIPTION
- batch call only when batch > threshold
- raise error when no rnvp data is returned