### PR TITLE
Add `ASP::AdresseCorrectionRequest` + formalize integration/rejects on addresse correction job returns

### DIFF
--- a/app/jobs/send_correction_adresse_job.rb
+++ b/app/jobs/send_correction_adresse_job.rb
@@ -14,7 +14,7 @@ class SendCorrectionAdresseJob < ApplicationJob
 
     enrich_with_rnvp!(payment_requests.map(&:student).uniq)
 
-    ASP::Request.create!(correction_adresse: true).send_correction_adresse!(payment_requests)
+    ASP::AdresseCorrectionRequest.create!.send_correction_adresse!(payment_requests)
   end
 
   private

--- a/app/models/asp/adresse_correction_request.rb
+++ b/app/models/asp/adresse_correction_request.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ASP
+  class AdresseCorrectionRequest < ApplicationRecord
+    include ASP::ResponseFileHandling
+
+    has_one_attached :correction_adresse_file, service: :ovh_asp
+    has_one_attached :correction_adresse_integrations_file, service: :ovh_asp
+    has_one_attached :correction_adresse_rejects_file, service: :ovh_asp
+
+    def send_correction_adresse!(payment_requests)
+      ActiveRecord::Base.transaction do
+        asp_file = ASP::Entities::CorrectionAdresseFichier.new(payment_requests)
+        asp_file.validate!
+        correction_adresse_file.attach(io: StringIO.new(asp_file.to_xml),
+                                       content_type: "text/xml", filename: asp_file.filename)
+        ASP::Server.upload_file!(io: asp_file.to_xml, path: asp_file.filename)
+        update!(sent_at: DateTime.now)
+      end
+    end
+  end
+end

--- a/app/models/asp/errors.rb
+++ b/app/models/asp/errors.rb
@@ -15,6 +15,8 @@ module ASP
     class MissingEstablishmentCommuneCodeError < Error; end
     class MissingEstablishmentPostalCodeError < Error; end
     class MissingRnvpDataError < Error; end
+    class CorrectionAdresseIdMismatchError < Error; end
+    class CorrectionAdresseRejectedError < Error; end
     class PaymentFileValidationError < Error; end
     class ReadingFileError < Error; end
 

--- a/app/models/asp/request.rb
+++ b/app/models/asp/request.rb
@@ -10,6 +10,8 @@ module ASP
     has_one_attached :rejects_file, service: :ovh_asp
     has_one_attached :integrations_file, service: :ovh_asp
     has_one_attached :correction_adresse_file, service: :ovh_asp
+    has_one_attached :correction_adresse_integrations_file, service: :ovh_asp
+    has_one_attached :correction_adresse_rejects_file, service: :ovh_asp
 
     has_many :asp_payment_requests,
              class_name: "ASP::PaymentRequest",
@@ -61,7 +63,7 @@ module ASP
 
         attach_asp_file!
         upload_file!
-        update_sent_timestamp!
+        update!(sent_at: DateTime.now)
         update_requests! unless rerun
       end
     end
@@ -82,10 +84,6 @@ module ASP
         io: @asp_file.to_xml,
         path: @asp_file.filename
       )
-    end
-
-    def update_sent_timestamp!
-      update!(sent_at: DateTime.now)
     end
 
     def update_requests!
@@ -113,7 +111,7 @@ module ASP
     private
 
     def reader_for(type)
-      klass = "ASP::Readers::#{type.capitalize}FileReader".constantize
+      klass = "ASP::Readers::#{type.to_s.camelize}FileReader".constantize
 
       klass.new(io: attachment_for(type).download)
     end

--- a/app/models/asp/request.rb
+++ b/app/models/asp/request.rb
@@ -2,6 +2,8 @@
 
 module ASP
   class Request < ApplicationRecord
+    include ASP::ResponseFileHandling
+
     MAX_FILES_PER_DAY = 10
     MAX_RECORDS_PER_FILE = 7000
     MAX_RECORDS_PER_WEEK = 100_000
@@ -9,9 +11,6 @@ module ASP
     has_one_attached :file, service: :ovh_asp
     has_one_attached :rejects_file, service: :ovh_asp
     has_one_attached :integrations_file, service: :ovh_asp
-    has_one_attached :correction_adresse_file, service: :ovh_asp
-    has_one_attached :correction_adresse_integrations_file, service: :ovh_asp
-    has_one_attached :correction_adresse_rejects_file, service: :ovh_asp
 
     has_many :asp_payment_requests,
              class_name: "ASP::PaymentRequest",
@@ -24,12 +23,11 @@ module ASP
     scope :sent_today, -> { sent_at(Time.current.all_day) }
     scope :sent_this_week, -> { sent_at(Time.current.all_week) } # thank you Active Support <3
 
-    validate :all_requests_ready?, on: :create, unless: :correction_adresse
+    validate :all_requests_ready?, on: :create
 
-    validates :asp_payment_requests, presence: true, unless: :correction_adresse
+    validates :asp_payment_requests, presence: true
 
     attr_reader :asp_file
-    attr_accessor :correction_adresse
 
     class << self
       def total_payment_requests_sent_today
@@ -68,17 +66,6 @@ module ASP
       end
     end
 
-    def send_correction_adresse!(payment_requests)
-      ActiveRecord::Base.transaction do
-        @asp_file = ASP::Entities::CorrectionAdresseFichier.new(payment_requests)
-        @asp_file.validate!
-        correction_adresse_file.attach(io: StringIO.new(@asp_file.to_xml),
-                                       content_type: "text/xml", filename: @asp_file.filename)
-        ASP::Server.upload_file!(io: @asp_file.to_xml, path: @asp_file.filename)
-        update!(sent_at: DateTime.now)
-      end
-    end
-
     def upload_file!
       ASP::Server.upload_file!(
         io: @asp_file.to_xml,
@@ -100,21 +87,7 @@ module ASP
                             .pluck("idEnregistrement")
     end
 
-    def parse_response_file!(type)
-      reader_for(type).process!
-    end
-
-    def attachment_for(type)
-      public_send "#{type}_file"
-    end
-
     private
-
-    def reader_for(type)
-      klass = "ASP::Readers::#{type.to_s.camelize}FileReader".constantize
-
-      klass.new(io: attachment_for(type).download)
-    end
 
     def results_attached?
       integrations_file.attached? || rejects_file.attached?

--- a/app/models/concerns/asp/response_file_handling.rb
+++ b/app/models/concerns/asp/response_file_handling.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module ASP
+  module ResponseFileHandling
+    extend ActiveSupport::Concern
+
+    def parse_response_file!(type)
+      reader_for(type).process!
+    end
+
+    def attachment_for(type)
+      public_send "#{type}_file"
+    end
+
+    private
+
+    def reader_for(type)
+      klass = "ASP::Readers::#{type.to_s.camelize}FileReader".constantize
+      klass.new(io: attachment_for(type).download)
+    end
+  end
+end

--- a/app/services/asp/file_saver.rb
+++ b/app/services/asp/file_saver.rb
@@ -35,9 +35,10 @@ module ASP
       if filename.payments_file? || filename.rectifications_file?
         ASP::PaymentReturn.find_or_create_by!(filename: filename.to_s)
       else
-        ASP::Request.joins(source_blob).find_by!("active_storage_blobs.filename": filename.original_filename).tap do |record|
-          record.correction_adresse = correction_adresse_response?
-        end
+        request = ASP::Request.joins(source_blob)
+                              .find_by!("active_storage_blobs.filename": filename.original_filename)
+        request.correction_adresse = correction_adresse_response?
+        request
       end
     end
 

--- a/app/services/asp/file_saver.rb
+++ b/app/services/asp/file_saver.rb
@@ -26,15 +26,27 @@ module ASP
     end
 
     def find_record!
+      find_payment_return_or_request!
+    rescue ActiveRecord::RecordNotFound
+      raise UnmatchedResponseFile
+    end
+
+    def find_payment_return_or_request!
       if filename.payments_file? || filename.rectifications_file?
         ASP::PaymentReturn.find_or_create_by!(filename: filename.to_s)
       else
-        ASP::Request
-          .joins(:file_blob)
-          .find_by!("active_storage_blobs.filename": filename.original_filename)
+        ASP::Request.joins(source_blob).find_by!("active_storage_blobs.filename": filename.original_filename).tap do |record|
+          record.correction_adresse = correction_adresse_response?
+        end
       end
-    rescue ActiveRecord::RecordNotFound
-      raise UnmatchedResponseFile
+    end
+
+    def source_blob
+      correction_adresse_response? ? :correction_adresse_file_blob : :file_blob
+    end
+
+    def correction_adresse_response?
+      filename.correction_adresse_integrations_file? || filename.correction_adresse_rejects_file?
     end
 
     def target_attachment

--- a/app/services/asp/file_saver.rb
+++ b/app/services/asp/file_saver.rb
@@ -34,16 +34,13 @@ module ASP
     def find_payment_return_or_request!
       if filename.payments_file? || filename.rectifications_file?
         ASP::PaymentReturn.find_or_create_by!(filename: filename.to_s)
+      elsif correction_adresse_response?
+        ASP::AdresseCorrectionRequest.joins(:correction_adresse_file_blob)
+                                     .find_by!("active_storage_blobs.filename": filename.original_filename)
       else
-        request = ASP::Request.joins(source_blob)
-                              .find_by!("active_storage_blobs.filename": filename.original_filename)
-        request.correction_adresse = correction_adresse_response?
-        request
+        ASP::Request.joins(:file_blob)
+                    .find_by!("active_storage_blobs.filename": filename.original_filename)
       end
-    end
-
-    def source_blob
-      correction_adresse_response? ? :correction_adresse_file_blob : :file_blob
     end
 
     def correction_adresse_response?

--- a/app/services/asp/filename.rb
+++ b/app/services/asp/filename.rb
@@ -2,7 +2,10 @@
 
 module ASP
   class Filename
-    TYPES = %i[rejects integrations payments rectifications].freeze
+    TYPES = %i[
+      rejects integrations payments rectifications
+      correction_adresse_integrations correction_adresse_rejects
+    ].freeze
 
     attr_reader :filename
 
@@ -21,9 +24,9 @@ module ASP
 
       filename_noext = File.basename(filename, ".*")
 
-      name = if rejects_file?
+      name = if rejects_file? || correction_adresse_rejects_file?
                filename_noext.split("integ_idp_").last
-             elsif integrations_file?
+             elsif integrations_file? || correction_adresse_integrations_file?
                filename_noext.split("generes_").last
              end
 
@@ -32,8 +35,12 @@ module ASP
 
     def kind
       case File.basename(filename)
+      when /^rejets_integ_idp.*correction_adresse/
+        :correction_adresse_rejects
       when /^rejets_integ_idp/
         :rejects
+      when /^identifiants_generes.*correction_adresse/
+        :correction_adresse_integrations
       when /^identifiants_generes/
         :integrations
       when /^renvoi_ordrereversement/

--- a/app/services/asp/readers/correction_adresse_integrations_file_reader.rb
+++ b/app/services/asp/readers/correction_adresse_integrations_file_reader.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module ASP
+  module Readers
+    class CorrectionAdresseIntegrationsFileReader < IntegrationsFileReader
+      def handle_request(request, row)
+        mismatches = id_mismatches(request, row)
+        return if mismatches.empty?
+
+        raise ASP::Errors::CorrectionAdresseIdMismatchError,
+              "ID mismatch for payment request #{request.id}: #{mismatches.join(', ')}"
+      end
+
+      private
+
+      def id_mismatches(request, row)
+        [
+          check_id(row, "idIndDoss", request.student.asp_individu_id),
+          check_id(row, "idDoss", request.schooling.asp_dossier_id),
+          check_id(row, "idPretaDoss", request.pfmp.asp_prestation_dossier_id)
+        ].compact
+      end
+
+      def check_id(row, key, expected)
+        return if row[key] == expected
+
+        "#{key}: expected #{expected}, got #{row[key]}"
+      end
+    end
+  end
+end

--- a/app/services/asp/readers/correction_adresse_rejects_file_reader.rb
+++ b/app/services/asp/readers/correction_adresse_rejects_file_reader.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module ASP
+  module Readers
+    class CorrectionAdresseRejectsFileReader < RejectsFileReader
+      def handle_request(request, row)
+        raise ASP::Errors::CorrectionAdresseRejectedError,
+              "Correction adresse rejected for payment request #{request.id}: #{row.to_h}"
+      end
+    end
+  end
+end

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aplypro
-  VERSION = "2.9.2"
+  VERSION = "2.9.3"
 end

--- a/db/migrate/20260410081816_create_asp_adresse_correction_requests.rb
+++ b/db/migrate/20260410081816_create_asp_adresse_correction_requests.rb
@@ -1,0 +1,8 @@
+class CreateASPAdresseCorrectionRequests < ActiveRecord::Migration[8.0]
+  def change
+    create_table :asp_adresse_correction_requests do |t|
+      t.timestamp :sent_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_12_19_113142) do
+ActiveRecord::Schema[8.0].define(version: 2026_04_10_081816) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "unaccent"
@@ -41,6 +41,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_12_19_113142) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "asp_adresse_correction_requests", force: :cascade do |t|
+    t.datetime "sent_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "asp_payment_request_transitions", force: :cascade do |t|

--- a/lib/asp/entities/correction_adresse_fichier.rb
+++ b/lib/asp/entities/correction_adresse_fichier.rb
@@ -3,6 +3,14 @@
 module ASP
   module Entities
     class CorrectionAdresseFichier < Fichier
+      def filename
+        @filename ||= [
+          "nps_ficimport_correction_adresse_idp",
+          ENV.fetch("APLYPRO_ASP_FILENAME"),
+          filename_timestamp
+        ].join("_").concat(".xml")
+      end
+
       def to_xml
         ASP::Builder.new({ encoding: "UTF-8" }) do |xml|
           xml.fichier(xmlns: XMLNS) do

--- a/spec/factories/asp/adresse_correction_requests.rb
+++ b/spec/factories/asp/adresse_correction_requests.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :asp_adresse_correction_request, class: "ASP::AdresseCorrectionRequest" do
+    transient do
+      outfile { "some content" }
+      filename { "filename.xml" }
+    end
+
+    trait :with_correction_adresse_file do
+      after(:create) do |request, ctx|
+        request.correction_adresse_file.attach(io: StringIO.new(ctx.outfile), filename: ctx.filename)
+      end
+    end
+  end
+end

--- a/spec/factories/asp/requests.rb
+++ b/spec/factories/asp/requests.rb
@@ -22,15 +22,5 @@ FactoryBot.define do
         request.asp_payment_requests << create(:asp_payment_request, :ready)
       end
     end
-
-    trait :correction_adresse do
-      after(:build) do |request|
-        request.correction_adresse = true
-      end
-
-      after(:create) do |request, ctx|
-        request.correction_adresse_file.attach(io: StringIO.new(ctx.outfile), filename: ctx.filename)
-      end
-    end
   end
 end

--- a/spec/factories/asp/requests.rb
+++ b/spec/factories/asp/requests.rb
@@ -22,5 +22,15 @@ FactoryBot.define do
         request.asp_payment_requests << create(:asp_payment_request, :ready)
       end
     end
+
+    trait :correction_adresse do
+      after(:build) do |request|
+        request.correction_adresse = true
+      end
+
+      after(:create) do |request, ctx|
+        request.correction_adresse_file.attach(io: StringIO.new(ctx.outfile), filename: ctx.filename)
+      end
+    end
   end
 end

--- a/spec/jobs/send_correction_adresse_job_spec.rb
+++ b/spec/jobs/send_correction_adresse_job_spec.rb
@@ -5,13 +5,13 @@ require "rails_helper"
 RSpec.describe SendCorrectionAdresseJob do
   include ActiveJob::TestHelper
 
-  let(:request_double) { instance_double(ASP::Request, send_correction_adresse!: nil) }
+  let(:request_double) { instance_double(ASP::AdresseCorrectionRequest, send_correction_adresse!: nil) }
   let(:rnvp_double) { instance_double(Omogen::Rnvp) }
   let(:pfmps) { create_list(:pfmp, 3, :rectified) }
   let(:pfmp_ids) { pfmps.map(&:id) }
 
   before do
-    allow(ASP::Request).to receive(:create!).and_return(request_double)
+    allow(ASP::AdresseCorrectionRequest).to receive(:create!).and_return(request_double)
     allow(Omogen::Rnvp).to receive(:new).and_return(rnvp_double)
     allow(rnvp_double).to receive(:address) { |student| { id: student.id } }
     allow(rnvp_double).to receive(:addresses) { |students| students.map { |s| { id: s.id } } }
@@ -20,7 +20,7 @@ RSpec.describe SendCorrectionAdresseJob do
   it "creates a correction adresse ASP request" do
     described_class.perform_now(pfmp_ids)
 
-    expect(ASP::Request).to have_received(:create!).with(correction_adresse: true)
+    expect(ASP::AdresseCorrectionRequest).to have_received(:create!)
     expect(request_double).to have_received(:send_correction_adresse!)
   end
 
@@ -28,7 +28,7 @@ RSpec.describe SendCorrectionAdresseJob do
     it "does not create an ASP request" do
       described_class.perform_now([])
 
-      expect(ASP::Request).not_to have_received(:create!)
+      expect(ASP::AdresseCorrectionRequest).not_to have_received(:create!)
     end
 
     it "does not call RNVP" do

--- a/spec/lib/asp/entities/correction_adresse_fichier_spec.rb
+++ b/spec/lib/asp/entities/correction_adresse_fichier_spec.rb
@@ -21,6 +21,16 @@ describe ASP::Entities::CorrectionAdresseFichier do
     end
   end
 
+  describe "#filename" do
+    it "includes correction_adresse in the name" do
+      expect(file.filename).to include("correction_adresse")
+    end
+
+    it "has an xml extension" do
+      expect(file.filename).to end_with(".xml")
+    end
+  end
+
   it "produces valid documents" do
     log_on_failure = -> { file.errors.each { |e| Rails.logger.debug "ASP validation error: #{e.message}\n" } }
 

--- a/spec/services/asp/file_saver_spec.rb
+++ b/spec/services/asp/file_saver_spec.rb
@@ -32,6 +32,34 @@ describe ASP::FileSaver do
     end
   end
 
+  {
+    correction_adresse_integrations: "identifiants_generes_nps_ficimport_correction_adresse_test.csv",
+    correction_adresse_rejects: "rejets_integ_idp_nps_ficimport_correction_adresse_test.csv"
+  }.each do |type, response_filename|
+    context "when the file is a #{type} file" do
+      let(:request) { create(:asp_request, :correction_adresse, filename: "nps_ficimport_correction_adresse_test.xml") }
+      let(:basename) { response_filename }
+
+      it "attaches to the right request" do
+        expect { file_saver.persist_file! }
+          .to change { request.reload.attachment_for(type).attached? }.from(false).to(true)
+      end
+
+      it "attaches with the right name" do
+        expect { file_saver.persist_file! }
+          .to change { request.reload.attachment_for(type).filename.to_s }.to(basename)
+      end
+
+      context "when the request cannot be found" do
+        before { request.correction_adresse_file.update!(filename: "bar.xml") }
+
+        it "raises an UnmatchedResponseFile error" do
+          expect { file_saver.persist_file! }.to raise_error(ASP::Errors::UnmatchedResponseFile)
+        end
+      end
+    end
+  end
+
   context "when the file is a payment returns file" do
     let(:basename) { build(:asp_filename, :payments) }
 

--- a/spec/services/asp/file_saver_spec.rb
+++ b/spec/services/asp/file_saver_spec.rb
@@ -37,7 +37,10 @@ describe ASP::FileSaver do
     correction_adresse_rejects: "rejets_integ_idp_nps_ficimport_correction_adresse_test.csv"
   }.each do |type, response_filename|
     context "when the file is a #{type} file" do
-      let(:request) { create(:asp_request, :correction_adresse, filename: "nps_ficimport_correction_adresse_test.xml") }
+      let(:request) do
+        create(:asp_adresse_correction_request, :with_correction_adresse_file,
+               filename: "nps_ficimport_correction_adresse_test.xml")
+      end
       let(:basename) { response_filename }
 
       it "attaches to the right request" do

--- a/spec/services/asp/filename_spec.rb
+++ b/spec/services/asp/filename_spec.rb
@@ -15,6 +15,18 @@ describe ASP::Filename do
         it { is_expected.to eq type }
       end
     end
+
+    context "when the filename looks like a correction_adresse_integrations file" do
+      let(:str) { "identifiants_generes_nps_ficimport_correction_adresse_foobar.csv" }
+
+      it { is_expected.to eq :correction_adresse_integrations }
+    end
+
+    context "when the filename looks like a correction_adresse_rejects file" do
+      let(:str) { "rejets_integ_idp_nps_ficimport_correction_adresse_foobar.csv" }
+
+      it { is_expected.to eq :correction_adresse_rejects }
+    end
   end
 
   describe "original_filename" do
@@ -32,6 +44,18 @@ describe ASP::Filename do
 
         it { is_expected.to eq "some identifier.xml" }
       end
+    end
+
+    context "when the file is correction_adresse_integrations file" do
+      let(:str) { "identifiants_generes_nps_ficimport_correction_adresse_some_identifier.csv" }
+
+      it { is_expected.to eq "nps_ficimport_correction_adresse_some_identifier.xml" }
+    end
+
+    context "when the file is correction_adresse_rejects file" do
+      let(:str) { "rejets_integ_idp_nps_ficimport_correction_adresse_some_identifier.csv" }
+
+      it { is_expected.to eq "nps_ficimport_correction_adresse_some_identifier.xml" }
     end
   end
 end

--- a/spec/services/asp/readers/correction_adresse_integrations_file_reader_spec.rb
+++ b/spec/services/asp/readers/correction_adresse_integrations_file_reader_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "./mock/factories/asp"
+
+describe ASP::Readers::CorrectionAdresseIntegrationsFileReader do
+  subject(:reader) { described_class.new(io: data) }
+
+  let(:asp_payment_request) { create(:asp_payment_request, :sent) }
+
+  before do
+    asp_payment_request.student.update!(asp_individu_id: "ind123")
+    asp_payment_request.schooling.update!(asp_dossier_id: "doss456")
+    asp_payment_request.pfmp.update!(asp_prestation_dossier_id: "preta789")
+  end
+
+  context "when all IDs match" do
+    let(:data) do
+      build(:asp_integration, payment_request: asp_payment_request,
+                              idIndDoss: "ind123", idDoss: "doss456", idPretaDoss: "preta789")
+    end
+
+    it "does not raise" do
+      expect { reader.process! }.not_to raise_error
+    end
+  end
+
+  context "when IDs do not match" do
+    let(:data) do
+      build(:asp_integration, payment_request: asp_payment_request,
+                              idIndDoss: "wrong_ind", idDoss: "wrong_doss", idPretaDoss: "preta789")
+    end
+
+    it "raises CorrectionAdresseIdMismatchError" do
+      expect { reader.process! }.to raise_error(ASP::Errors::CorrectionAdresseIdMismatchError)
+    end
+
+    it "includes each mismatch in the error message" do
+      expect { reader.process! }
+        .to raise_error(ASP::Errors::CorrectionAdresseIdMismatchError, /idIndDoss.*idDoss/m)
+    end
+  end
+end

--- a/spec/services/asp/readers/correction_adresse_rejects_file_reader_spec.rb
+++ b/spec/services/asp/readers/correction_adresse_rejects_file_reader_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+require "./mock/factories/asp"
+
+describe ASP::Readers::CorrectionAdresseRejectsFileReader do
+  subject(:reader) { described_class.new(io: data) }
+
+  let(:asp_payment_request) { create(:asp_payment_request, :sent) }
+  let(:data) { build(:asp_reject, payment_request: asp_payment_request) }
+
+  it "raises CorrectionAdresseRejectedError" do
+    expect { reader.process! }.to raise_error(ASP::Errors::CorrectionAdresseRejectedError)
+  end
+
+  it "includes the payment request id in the error message" do
+    expect { reader.process! }
+      .to raise_error(ASP::Errors::CorrectionAdresseRejectedError, /#{asp_payment_request.id}/)
+  end
+end


### PR DESCRIPTION
- new model to track the correction send outs
- tag correction files with appropriate name
- add special file reader for integrations + rejects of addresse correction returns

So here's what happens now:
- correction XML gets sent
- we get feedback from Serapis with either integration file or rejects file (properly tagged with name)
- we parse the file and check that they were sent by us through an `ASP::AdresseCorrectionRequest`
- we check that everything is "Ok" (no change of ids)
- we attach the csv files to the `ASP::AdresseCorrectionRequest`
- we remove the files from the FTP

Q: Does it make sense to add a transition to the p_r state machine for this?
Imho no because this process is completely orthogonal to the movements of payment states.

Important ⚠️ : 
- remember to delete manually the one integration file created by corrections in the FTP (`*_20260327081022.csv`) -> DONE
- delete sole orphaned ASP::Request with attachments (id: 2687) -> DONE