### PR TITLE
Gestion du conflit dans le mapper FREGATA entre le code 'division' et 'statutApprenant'

### DIFF
--- a/app/apis/students_api/fregata/mappers/schooling_mapper.rb
+++ b/app/apis/students_api/fregata/mappers/schooling_mapper.rb
@@ -9,10 +9,10 @@ module StudentsApi
         define! do
           deep_symbolize_keys
 
-          unwrap :statutApprenant
           unwrap :apprenant
           unwrap :sectionReference
           unwrap :division
+          unwrap :statutApprenant
 
           rename_keys(
             libelle: :label,

--- a/app/models/asp/payment_request.rb
+++ b/app/models/asp/payment_request.rb
@@ -177,5 +177,9 @@ module ASP
 
       "#{code_pays}#{cle}#{zonebban}"
     end
+
+    def sent_record_xml
+      Nokogiri::XML(asp_request.file.download).at("ENREGISTREMENT[idEnregistrement='#{id}']").to_xml
+    end
   end
 end

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aplypro
-  VERSION = "2.10.5"
+  VERSION = "2.10.6"
 end

--- a/spec/apis/students_api/fregata/mappers/schooling_mapper_spec.rb
+++ b/spec/apis/students_api/fregata/mappers/schooling_mapper_spec.rb
@@ -47,4 +47,25 @@ describe StudentsApi::Fregata::Mappers::SchoolingMapper do
       end
     end
   end
+
+  describe "unwrap order" do
+    let(:data) do
+      build(
+        :fregata_student,
+        statutApprenant: { code: "2501" },
+        division: {
+          code: "2503",
+          libelle: "2NDE JARDINERIE"
+        }
+      )
+    end
+
+    it "maps the statutApprenant code" do
+      expect(mapped[:status]).to eq :student
+    end
+
+    it "still maps the label" do
+      expect(mapped[:label]).to eq "2NDE JARDINERIE"
+    end
+  end
 end


### PR DESCRIPTION
L'attribut `code` de `division` se fait écraser par l'attribut `code` de `sectionReference`, en inversant l'ordre des `unwrap`, le `code` de `division` devrait être la donnée restante.